### PR TITLE
General code cleanup

### DIFF
--- a/CheckPort/Program.cs
+++ b/CheckPort/Program.cs
@@ -12,7 +12,7 @@ namespace CheckPort
         static void Main(string[] args)
         {
             Console.WriteLine("[*] Looking for available ports..");
-            string port = checkPorts(new string[] { "SYSTEM", "ANY" }).ToString();
+            string port = checkPorts(new[] { "SYSTEM", "ANY" }).ToString();
             if (port == "-1")
             {
                 Console.WriteLine("[-] No available ports found");

--- a/CheckPort/Program.cs
+++ b/CheckPort/Program.cs
@@ -20,6 +20,7 @@ namespace CheckPort
                 return;
             }
         }
+        
         public static int checkPorts(string[] names)
         {
             IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
@@ -39,6 +40,7 @@ namespace CheckPort
             }
             return -1;
         }
+        
         public static bool checkPort(int port, string name = "SYSTEM")
         {
             INetFwMgr mgr = (INetFwMgr)Activator.CreateInstance(Type.GetTypeFromProgID("HNetCfg.FwMgr"));

--- a/CheckPort/Program.cs
+++ b/CheckPort/Program.cs
@@ -1,4 +1,4 @@
-﻿using NetFwTypeLib;
+using NetFwTypeLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/CheckPort/Properties/AssemblyInfo.cs
+++ b/CheckPort/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/KrbRelay/Clients/Attacks/Http/ADCS.cs
+++ b/KrbRelay/Clients/Attacks/Http/ADCS.cs
@@ -65,7 +65,7 @@ namespace KrbRelay.Clients.Attacks.Http
             if (string.IsNullOrEmpty(template))
                 CertificateTemplates = templateHunter();
             else
-                CertificateTemplates = new string[] { template };
+                CertificateTemplates = new[] { template };
 
             string pattern = @"location=""certnew.cer\?ReqID=(.*?)&";
             Regex rgx = new Regex(pattern, RegexOptions.IgnoreCase);

--- a/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Data/DNWithBinary.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Data/DNWithBinary.cs
@@ -1,6 +1,6 @@
 ﻿namespace DSInternals.Common.Data
 {
-    using DSInternals.Common.Properties;
+    using Properties;
     using System;
 
     /// <summary>
@@ -31,8 +31,8 @@
             Validator.AssertNotNullOrEmpty(dn, nameof(dn));
             Validator.AssertNotNull(binary, nameof(binary));
 
-            this.DistinguishedName = dn;
-            this.Binary = binary;
+            DistinguishedName = dn;
+            Binary = binary;
         }
 
         public static DNWithBinary Parse(string dnWithBinary)
@@ -57,7 +57,7 @@
 
         public override string ToString()
         {
-            return String.Format(StringFormat, this.Binary.Length * 2, this.Binary.ToHex(true), this.DistinguishedName);
+            return String.Format(StringFormat, Binary.Length * 2, Binary.ToHex(true), DistinguishedName);
         }
     }
 }

--- a/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Data/Hello/CustomKeyInformation.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Data/Hello/CustomKeyInformation.cs
@@ -82,8 +82,8 @@
 
         public CustomKeyInformation(KeyFlags flags)
         {
-            this.Version = CurrentVersion;
-            this.Flags = flags;
+            Version = CurrentVersion;
+            Flags = flags;
         }
 
         public CustomKeyInformation(byte[] blob)
@@ -95,34 +95,34 @@
             using (var stream = new MemoryStream(blob, false))
             {
                 // An 8-bit unsigned integer that must be set to 1:
-                this.Version = (byte)stream.ReadByte();
+                Version = (byte)stream.ReadByte();
 
                 // An 8-bit unsigned integer that specifies zero or more bit-flag values.
-                this.Flags = (KeyFlags)stream.ReadByte();
+                Flags = (KeyFlags)stream.ReadByte();
 
                 // Note: This structure has two possible representations. In the first representation, only the Version and Flags fields are present; in this case the structure has a total size of two bytes. In the second representation, all additional fields shown below are also present; in this case, the structure's total size is variable. Differentiating between the two representations must be inferred using only the total size.
                 if (stream.Position < stream.Length)
                 {
                     // An 8-bit unsigned integer that specifies one of the volume types.
-                    this.VolumeType = (VolumeType)stream.ReadByte();
+                    VolumeType = (VolumeType)stream.ReadByte();
                 }
 
                 if (stream.Position < stream.Length)
                 {
                     // An 8-bit unsigned integer that specifies whether the device associated with this credential supports notification.
-                    this.SupportsNotification = Convert.ToBoolean(stream.ReadByte());
+                    SupportsNotification = Convert.ToBoolean(stream.ReadByte());
                 }
 
                 if (stream.Position < stream.Length)
                 {
                     // An 8-bit unsigned integer that specifies the version of the File Encryption Key (FEK). This field must be set to 1.
-                    this.FekKeyVersion = (byte)stream.ReadByte();
+                    FekKeyVersion = (byte)stream.ReadByte();
                 }
 
                 if (stream.Position < stream.Length)
                 {
                     // An 8-bit unsigned integer that specifies the strength of the NGC key.
-                    this.Strength = (KeyStrength)stream.ReadByte();
+                    Strength = (KeyStrength)stream.ReadByte();
                 }
 
                 if (stream.Position < stream.Length)
@@ -130,14 +130,14 @@
                     // 10 bytes reserved for future use.
                     // Note: With FIDO, Azure incorrectly puts here 9 bytes instead of 10.
                     int actualReservedSize = (int)Math.Min(ReservedSize, stream.Length - stream.Position);
-                    this.Reserved = new byte[actualReservedSize];
-                    stream.Read(this.Reserved, 0, actualReservedSize);
+                    Reserved = new byte[actualReservedSize];
+                    stream.Read(Reserved, 0, actualReservedSize);
                 }
 
                 if (stream.Position < stream.Length)
                 {
                     // Extended custom key information.
-                    this.EncodedExtendedCKI = stream.ReadToEnd();
+                    EncodedExtendedCKI = stream.ReadToEnd();
                 }
             }
         }
@@ -146,37 +146,37 @@
         {
             using (var stream = new MemoryStream())
             {
-                stream.WriteByte(this.Version);
-                stream.WriteByte((byte)this.Flags);
+                stream.WriteByte(Version);
+                stream.WriteByte((byte)Flags);
 
-                if (this.VolumeType.HasValue)
+                if (VolumeType.HasValue)
                 {
-                    stream.WriteByte((byte)this.VolumeType.Value);
+                    stream.WriteByte((byte)VolumeType.Value);
                 }
 
-                if (this.SupportsNotification.HasValue)
+                if (SupportsNotification.HasValue)
                 {
-                    stream.WriteByte(Convert.ToByte(this.SupportsNotification.Value));
+                    stream.WriteByte(Convert.ToByte(SupportsNotification.Value));
                 }
 
-                if (this.FekKeyVersion.HasValue)
+                if (FekKeyVersion.HasValue)
                 {
-                    stream.WriteByte(this.FekKeyVersion.Value);
+                    stream.WriteByte(FekKeyVersion.Value);
                 }
 
-                if (this.Strength.HasValue)
+                if (Strength.HasValue)
                 {
-                    stream.WriteByte((byte)this.Strength.Value);
+                    stream.WriteByte((byte)Strength.Value);
                 }
 
-                if (this.Reserved != null)
+                if (Reserved != null)
                 {
-                    stream.Write(this.Reserved, 0, Reserved.Length);
+                    stream.Write(Reserved, 0, Reserved.Length);
                 }
 
-                if (this.EncodedExtendedCKI != null)
+                if (EncodedExtendedCKI != null)
                 {
-                    stream.Write(this.EncodedExtendedCKI, 0, this.EncodedExtendedCKI.Length);
+                    stream.Write(EncodedExtendedCKI, 0, EncodedExtendedCKI.Length);
                 }
 
                 return stream.ToArray();

--- a/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Extensions/ByteArrayExtensions.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/DSInternals.Common/Extensions/ByteArrayExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace DSInternals.Common
 {
-    using DSInternals.Common.Properties;
+    using Properties;
     using System;
     using System.IO;
     using System.Security;

--- a/KrbRelay/Clients/Attacks/Ldap/Generic.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/Generic.cs
@@ -63,7 +63,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             Helpers.StructureArrayToPtr(mod, ptr, true);
 
             //int rest = ldap_modify_ext(ld, dn, ptr, IntPtr.Zero, IntPtr.Zero, out int pMessage);
-            int rest = Natives.ldap_modify_s(ld, dn, ptr);
+            int rest = ldap_modify_s(ld, dn, ptr);
             Console.WriteLine("[*] ldap_modify: {0}", (LdapStatus)rest);
 
             mod.ForEach(_ =>
@@ -131,7 +131,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             IntPtr pLaps = Helpers.AllocHGlobalIntPtrArray(1 + 1);
             var controlPtr = Marshal.StringToHGlobalUni("DistinguishedName");
             Marshal.WriteIntPtr(pLaps, IntPtr.Size * 0, controlPtr);
-            var search = Natives.ldap_search(
+            var search = ldap_search(
                 ld,
                 $"{Program.domainDN}",
                 (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
@@ -141,7 +141,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             //Console.WriteLine("[*] msgID: {0}", search);
 
             IntPtr pMessage = IntPtr.Zero;
-            var r = Natives.ldap_result(
+            var r = ldap_result(
                 ld,
                 search,
                 0,
@@ -159,7 +159,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             var result = new List<byte[]>();
             foreach (var tempPtr in Helpers.GetPointerArray(vals))
             {
-                Natives.berval bervalue = (Natives.berval)Marshal.PtrToStructure(tempPtr, typeof(Natives.berval));
+                berval bervalue = (berval)Marshal.PtrToStructure(tempPtr, typeof(berval));
                 if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
                 {
                     var byteArray = new byte[bervalue.bv_len];
@@ -177,7 +177,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
 
         public static string getPropertyValue(IntPtr ld, string adObject, string property)
         {
-            var timeout = new Natives.LDAP_TIMEVAL
+            var timeout = new LDAP_TIMEVAL
             {
                 tv_sec = (int)(new TimeSpan(0, 0, 30).Ticks / TimeSpan.TicksPerSecond)
             };
@@ -212,7 +212,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             var result = new List<byte[]>();
             foreach (var tempPtr in Helpers.GetPointerArray(vals))
             {
-                Natives.berval bervalue = (Natives.berval)Marshal.PtrToStructure(tempPtr, typeof(Natives.berval));
+                berval bervalue = (berval)Marshal.PtrToStructure(tempPtr, typeof(berval));
                 if (bervalue.bv_len > 0 && bervalue.bv_val != IntPtr.Zero)
                 {
                     var byteArray = new byte[bervalue.bv_len];

--- a/KrbRelay/Clients/Attacks/Ldap/LAPS.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/LAPS.cs
@@ -11,7 +11,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
     {
         public static void read(IntPtr ld, string computer = "")
         {
-            var timeout = new Natives.LDAP_TIMEVAL
+            var timeout = new LDAP_TIMEVAL
             {
                 tv_sec = (int)(new TimeSpan(0, 0, 30).Ticks / TimeSpan.TicksPerSecond)
             };
@@ -22,7 +22,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             int search = 0;
             if (string.IsNullOrEmpty(computer))
             {
-                search = Natives.ldap_search(
+                search = ldap_search(
                     ld,
                     $"{Program.domainDN}",
                     (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
@@ -32,7 +32,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             }
             else
             {
-                search = Natives.ldap_search(
+                search = ldap_search(
                     ld,
                     $"{Program.domainDN}",
                     (int)LdapSearchScope.LDAP_SCOPE_SUBTREE,
@@ -43,7 +43,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             //Console.WriteLine("[*] msgID: {0}", search);
 
             IntPtr pMessage = IntPtr.Zero;
-            var r = Natives.ldap_result(
+            var r = ldap_result(
                 ld,
                 search,
                 1,
@@ -52,8 +52,8 @@ namespace KrbRelay.Clients.Attacks.Ldap
             Console.WriteLine("[*] ldap_result: {0}", (LdapResultType)r);
             Dictionary<string, Dictionary<string, List<byte[]>>> result = new Dictionary<string, Dictionary<string, List<byte[]>>>();
             var ber = Marshal.AllocHGlobal(IntPtr.Size);
-            for (var entry = Natives.ldap_first_entry(ld, pMessage); entry != IntPtr.Zero;
-                entry = Natives.ldap_next_entry(ld, entry))
+            for (var entry = ldap_first_entry(ld, pMessage); entry != IntPtr.Zero;
+                entry = ldap_next_entry(ld, entry))
             {
                 string dn = Generic.GetLdapDn(ld, entry);//.Split(',').First().Replace("CN=","");
                 Dictionary<string, List<byte[]>> aa = Generic.GetLdapAttributes(ld, entry, ref ber);

--- a/KrbRelay/Clients/Attacks/Ldap/gMSA.cs
+++ b/KrbRelay/Clients/Attacks/Ldap/gMSA.cs
@@ -43,7 +43,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             //Console.WriteLine("[*] msgID: {0}", search);
 
             IntPtr pMessage = IntPtr.Zero;
-            var r = Natives.ldap_result(
+            var r = ldap_result(
                 ld,
                 search,
                 1,
@@ -52,7 +52,7 @@ namespace KrbRelay.Clients.Attacks.Ldap
             Console.WriteLine("[*] ldap_result: {0}", (LdapResultType)r);
             Dictionary<string, Dictionary<string, List<byte[]>>> result = new Dictionary<string, Dictionary<string, List<byte[]>>>();
             var ber = Marshal.AllocHGlobal(IntPtr.Size);
-            for (var entry = ldap_first_entry(ld, pMessage); entry != IntPtr.Zero; entry = Natives.ldap_next_entry(ld, entry))
+            for (var entry = ldap_first_entry(ld, pMessage); entry != IntPtr.Zero; entry = ldap_next_entry(ld, entry))
             {
                 string dn = Generic.GetLdapDn(ld, entry);
                 Dictionary<string, List<byte[]>> aa = Generic.GetLdapAttributes(ld, entry, ref ber);

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/Crypto.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/Crypto.cs
@@ -83,8 +83,8 @@ namespace KrbRelay.HiveParser
                     manualPadding.Add(0x00);
                 }
                 byte[] concat = new byte[value.Length + manualPadding.Count];
-                System.Buffer.BlockCopy(value, 0, concat, 0, value.Length);
-                System.Buffer.BlockCopy(manualPadding.ToArray(), 0, concat, value.Length, manualPadding.Count);
+                Buffer.BlockCopy(value, 0, concat, 0, value.Length);
+                Buffer.BlockCopy(manualPadding.ToArray(), 0, concat, value.Length, manualPadding.Count);
                 value = concat;
             }
 

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/NodeKey.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/NodeKey.cs
@@ -40,44 +40,44 @@ namespace KrbRelay.HiveParser
                 throw new NotSupportedException("Bad nk header");
 
             long startingOffset = hive.BaseStream.Position;
-            this.IsRootKey = (buf[2] == 0x2c) ? true : false;
+            IsRootKey = (buf[2] == 0x2c) ? true : false;
 
-            this.Timestamp = DateTime.FromFileTime(hive.ReadInt64());
-
-            hive.BaseStream.Position += 4;
-
-            this.ParentOffset = hive.ReadInt32();
-            this.SubkeysCount = hive.ReadInt32();
+            Timestamp = DateTime.FromFileTime(hive.ReadInt64());
 
             hive.BaseStream.Position += 4;
 
-            this.LFRecordOffset = hive.ReadInt32();
+            ParentOffset = hive.ReadInt32();
+            SubkeysCount = hive.ReadInt32();
 
             hive.BaseStream.Position += 4;
 
-            this.ValuesCount = hive.ReadInt32();
-            this.ValueListOffset = hive.ReadInt32();
-            this.SecurityKeyOffset = hive.ReadInt32();
-            this.ClassnameOffset = hive.ReadInt32();
+            LFRecordOffset = hive.ReadInt32();
+
+            hive.BaseStream.Position += 4;
+
+            ValuesCount = hive.ReadInt32();
+            ValueListOffset = hive.ReadInt32();
+            SecurityKeyOffset = hive.ReadInt32();
+            ClassnameOffset = hive.ReadInt32();
 
             hive.BaseStream.Position += (startingOffset + 68) - hive.BaseStream.Position;
 
-            this.NameLength = hive.ReadInt16();
-            this.ClassnameLength = hive.ReadInt16();
+            NameLength = hive.ReadInt16();
+            ClassnameLength = hive.ReadInt16();
 
-            buf = hive.ReadBytes(this.NameLength);
-            this.Name = System.Text.Encoding.UTF8.GetString(buf);
+            buf = hive.ReadBytes(NameLength);
+            Name = System.Text.Encoding.UTF8.GetString(buf);
 
-            hive.BaseStream.Position = this.ClassnameOffset + 4 + 4096;
-            this.ClassnameData = hive.ReadBytes(this.ClassnameLength);
+            hive.BaseStream.Position = ClassnameOffset + 4 + 4096;
+            ClassnameData = hive.ReadBytes(ClassnameLength);
         }
 
         private void ReadChildrenNodes(BinaryReader hive)
         {
-            this.ChildNodes = new List<NodeKey>();
-            if (this.LFRecordOffset != -1)
+            ChildNodes = new List<NodeKey>();
+            if (LFRecordOffset != -1)
             {
-                hive.BaseStream.Position = 4096 + this.LFRecordOffset + 4;
+                hive.BaseStream.Position = 4096 + LFRecordOffset + 4;
 
                 byte[] buf = hive.ReadBytes(2);
 
@@ -122,7 +122,7 @@ namespace KrbRelay.HiveParser
                 //byte[] check = hive.ReadBytes(4);
                 hive.BaseStream.Position = 4096 + newoffset + 4;
                 NodeKey nk = new NodeKey(hive) { ParentNodeKey = this };
-                this.ChildNodes.Add(nk);
+                ChildNodes.Add(nk);
             }
 
             hive.BaseStream.Position = topOfList + (count * 8);
@@ -130,24 +130,24 @@ namespace KrbRelay.HiveParser
 
         private void ReadChildValues(BinaryReader hive)
         {
-            this.ChildValues = new List<ValueKey>();
-            if (this.ValueListOffset != -1)
+            ChildValues = new List<ValueKey>();
+            if (ValueListOffset != -1)
             {
-                hive.BaseStream.Position = 4096 + this.ValueListOffset + 4;
+                hive.BaseStream.Position = 4096 + ValueListOffset + 4;
 
-                for (int i = 0; i < this.ValuesCount; i++)
+                for (int i = 0; i < ValuesCount; i++)
                 {
-                    hive.BaseStream.Position = 4096 + this.ValueListOffset + 4 + (i * 4);
+                    hive.BaseStream.Position = 4096 + ValueListOffset + 4 + (i * 4);
                     int offset = hive.ReadInt32();
                     hive.BaseStream.Position = 4096 + offset + 4;
-                    this.ChildValues.Add(new ValueKey(hive));
+                    ChildValues.Add(new ValueKey(hive));
                 }
             }
         }
 
         public byte[] getChildValues(string valueName)
         {
-            ValueKey targetData = this.ChildValues.Find(x => x.Name.Contains(valueName));
+            ValueKey targetData = ChildValues.Find(x => x.Name.Contains(valueName));
             return targetData.Data;
         }
     }

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/Registry.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/Registry.cs
@@ -93,7 +93,7 @@ namespace KrbRelay.HiveParser
                 byte[] almpassword = Encoding.ASCII.GetBytes("LMPASSWORD\0");
                 foreach (NodeKey user in targetNode.ChildNodes.Where(x => x.Name.Contains("00000")))
                 {
-                    byte[] rid = BitConverter.GetBytes(System.Int32.Parse(user.Name, System.Globalization.NumberStyles.HexNumber));
+                    byte[] rid = BitConverter.GetBytes(Int32.Parse(user.Name, System.Globalization.NumberStyles.HexNumber));
                     byte[] v = user.getChildValues("V");
                     int offset = BitConverter.ToInt32(v, 12) + 204;
                     int length = BitConverter.ToInt32(v, 16);
@@ -153,7 +153,7 @@ namespace KrbRelay.HiveParser
                             ntHash = Crypto.DecryptSingleHash(desEncryptedHash, user.Name).Replace("-", "");
                         }
                     }
-                    string ridStr = System.Int32.Parse(user.Name, System.Globalization.NumberStyles.HexNumber).ToString();
+                    string ridStr = Int32.Parse(user.Name, System.Globalization.NumberStyles.HexNumber).ToString();
                     string hashes = (lmHash + ":" + ntHash);
                     retVal.Add(string.Format("{0}:{1}:{2}", username, ridStr, hashes.ToLower()));
                 }
@@ -289,12 +289,12 @@ namespace KrbRelay.HiveParser
             }
             else if (keyName.ToUpper().StartsWith("ASPNET_WP_PASSWORD"))
             {
-                secretOutput += ("ASPNET:" + System.Text.Encoding.Unicode.GetString(secretBlob.secret));
+                secretOutput += ("ASPNET:" + Encoding.Unicode.GetString(secretBlob.secret));
             }
             else
             {
                 secretOutput += ("[!] Secret type not supported yet - outputing raw secret as unicode:\r\n");
-                secretOutput += (System.Text.Encoding.Unicode.GetString(secretBlob.secret));
+                secretOutput += (Encoding.Unicode.GetString(secretBlob.secret));
             }
             return secretOutput;
         }

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/Registry.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/Registry.cs
@@ -22,7 +22,7 @@ namespace KrbRelay.HiveParser
             int cs = BitConverter.ToInt32(controlSet.Data, 0);
 
             StringBuilder scrambledKey = new StringBuilder();
-            foreach (string key in new string[] { "JD", "Skew1", "GBG", "Data" })
+            foreach (string key in new[] { "JD", "Skew1", "GBG", "Data" })
             {
                 NodeKey nk = GetNodeKey(systemHive, "ControlSet00" + cs + "\\Control\\Lsa\\" + key);
 

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/RegistryHive.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/RegistryHive.cs
@@ -31,7 +31,7 @@ namespace KrbRelay.HiveParser
         public RegistryHive(BinaryReader reader)
         {
             reader.BaseStream.Position += 4132 - reader.BaseStream.Position;
-            this.RootKey = new NodeKey(reader);
+            RootKey = new NodeKey(reader);
         }
 
         public string Filepath { get; set; }

--- a/KrbRelay/Clients/Attacks/Smb/HiveParser/ValueKey.cs
+++ b/KrbRelay/Clients/Attacks/Smb/HiveParser/ValueKey.cs
@@ -13,23 +13,23 @@ namespace KrbRelay.HiveParser
             if (buf[0] != 0x76 && buf[1] != 0x6b)
                 throw new NotSupportedException("Bad vk header");
 
-            this.NameLength = hive.ReadInt16();
-            this.DataLength = hive.ReadInt32();
+            NameLength = hive.ReadInt16();
+            DataLength = hive.ReadInt32();
 
             byte[] databuf = hive.ReadBytes(4);
 
-            this.ValueType = hive.ReadInt32();
+            ValueType = hive.ReadInt32();
             hive.BaseStream.Position += 4;
 
-            buf = hive.ReadBytes(this.NameLength);
-            this.Name = (this.NameLength == 0) ? "Default" : System.Text.Encoding.UTF8.GetString(buf);
+            buf = hive.ReadBytes(NameLength);
+            Name = (NameLength == 0) ? "Default" : System.Text.Encoding.UTF8.GetString(buf);
 
-            if (this.DataLength < 5)
-                this.Data = databuf;
+            if (DataLength < 5)
+                Data = databuf;
             else
             {
                 hive.BaseStream.Position = 4096 + BitConverter.ToInt32(databuf, 0) + 4;
-                this.Data = hive.ReadBytes(this.DataLength);
+                Data = hive.ReadBytes(DataLength);
             }
         }
 

--- a/KrbRelay/Clients/Attacks/Smb/RemoteRegistry.cs
+++ b/KrbRelay/Clients/Attacks/Smb/RemoteRegistry.cs
@@ -41,7 +41,7 @@ namespace KrbRelay.Clients.Attacks.Smb
                 RrpServiceHelper.BaseRegCloseKey(rpc, sys, out status);
 
                 StringBuilder scrambledKey = new StringBuilder();
-                foreach (var key in new string[] { "JD", "Skew1", "GBG", "Data" }) //,
+                foreach (var key in new[] { "JD", "Skew1", "GBG", "Data" }) //,
                 {
                     var hBootKey = RrpServiceHelper.BaseRegOpenKey(rpc, hKey, $"SYSTEM\\CurrentControlSet\\Control\\Lsa\\{key}\x00", out status);
                     var v = RrpServiceHelper.baseRegQueryInfoKey(rpc, hBootKey, out status);

--- a/KrbRelay/Clients/Attacks/Smb/Shares.cs
+++ b/KrbRelay/Clients/Attacks/Smb/Shares.cs
@@ -54,7 +54,7 @@ namespace KrbRelay.Clients.Attacks.Smb
             var status = fileStore.CreateFile(out fileHandle, out fileStatus, path, AccessMask.GENERIC_READ | AccessMask.SYNCHRONIZE, SMBLibrary.FileAttributes.Normal, ShareAccess.Read, CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT, null);
             if (status == NTStatus.STATUS_SUCCESS)
             {
-                using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
+                using (MemoryStream stream = new MemoryStream())
                 {
                     byte[] data;
                     long bytesRead = 0;
@@ -107,7 +107,7 @@ namespace KrbRelay.Clients.Attacks.Smb
             if (status == NTStatus.STATUS_SUCCESS)
             {
                 int writeOffset = 0;
-                using (System.IO.MemoryStream stream = new System.IO.MemoryStream(content))
+                using (MemoryStream stream = new MemoryStream(content))
                 {
                     while (stream.Position < stream.Length)
                     {

--- a/KrbRelay/Clients/Http.cs
+++ b/KrbRelay/Clients/Http.cs
@@ -1,6 +1,4 @@
-﻿using Org.BouncyCastle.X509;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/KrbRelay/Clients/Http.cs
+++ b/KrbRelay/Clients/Http.cs
@@ -34,12 +34,10 @@ namespace KrbRelay.Clients
                 Console.WriteLine("[+] HTTP session established");
 
                 //Kerberos auth may not require set-cookies
-                IEnumerable<string> cookies = null;
                 foreach (var h in result.Headers)
                 {
                     if (h.Key == "Set-Cookie")
                     {
-                        cookies = h.Value;
                         Console.WriteLine("[*] Authentication Cookie;\n" + string.Join(";", h.Value));
                     }
                 }
@@ -85,23 +83,6 @@ namespace KrbRelay.Clients
                     }
                 }
             }
-        }
-    }
-
-    internal class TrustAll : ICertificatePolicy
-    {
-        public TrustAll()
-        {
-        }
-
-        public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate, WebRequest request, int certificateProblem)
-        {
-            return true;
-        }
-
-        public bool CheckValidationResult(ServicePoint srvPoint, System.Security.Cryptography.X509Certificates.X509Certificate certificate, WebRequest request, int certificateProblem)
-        {
-            return true;
         }
     }
 }

--- a/KrbRelay/Com/COMInterfaces.cs
+++ b/KrbRelay/Com/COMInterfaces.cs
@@ -15,9 +15,7 @@
 //    along with OleViewDotNet.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace KrbRelay.Com
 {

--- a/KrbRelay/Com/COMUtilities.cs
+++ b/KrbRelay/Com/COMUtilities.cs
@@ -14,25 +14,13 @@
 //    You should have received a copy of the GNU General Public License
 //    along with OleViewDotNet.  If not, see <http://www.gnu.org/licenses/>.
 
-using Microsoft.CSharp;
-using Microsoft.Win32;
 using System;
-using System.CodeDom;
-using System.CodeDom.Compiler;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Security;
-using System.Security.Cryptography;
-using System.Security.Principal;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 //using System.Windows.Forms;

--- a/KrbRelay/IStorage/IEnumSTATSTG.cs
+++ b/KrbRelay/IStorage/IEnumSTATSTG.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelay
 {

--- a/KrbRelay/IStorage/ILockBytes.cs
+++ b/KrbRelay/IStorage/ILockBytes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelay
 {

--- a/KrbRelay/IStorage/ILockBytes.cs
+++ b/KrbRelay/IStorage/ILockBytes.cs
@@ -20,6 +20,6 @@ namespace KrbRelay
 
         void UnlockRegion(long libOffset, long cb, int dwLockType);
 
-        void Stat(out System.Runtime.InteropServices.STATSTG pstatstg, int grfStatFlag);
+        void Stat(out STATSTG pstatstg, int grfStatFlag);
     }
 }

--- a/KrbRelay/IStorage/IStream.cs
+++ b/KrbRelay/IStorage/IStream.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace KrbRelay
 {

--- a/KrbRelay/Misc/Helpers.cs
+++ b/KrbRelay/Misc/Helpers.cs
@@ -25,12 +25,12 @@ namespace KrbRelay
             // locate the crypto system for the hash type we want
             int status = Interop.CDLocateCSystem(etype, out pCSystemPtr);
 
-            pCSystem = (Interop.KERB_ECRYPT)System.Runtime.InteropServices.Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
+            pCSystem = (Interop.KERB_ECRYPT)Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
             if (status != 0)
-                throw new System.ComponentModel.Win32Exception(status, "Error on CDLocateCSystem");
+                throw new Win32Exception(status, "Error on CDLocateCSystem");
 
             // get the delegate for the password hash function
-            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
+            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
             Interop.UNICODE_STRING passwordUnicode = new Interop.UNICODE_STRING(password);
             Interop.UNICODE_STRING saltUnicode = new Interop.UNICODE_STRING(salt);
 
@@ -41,7 +41,7 @@ namespace KrbRelay
             if (status != 0)
                 throw new Win32Exception(status);
 
-            return System.BitConverter.ToString(output).Replace("-", "");
+            return BitConverter.ToString(output).Replace("-", "");
         }
 
         public static byte[] unhexlify(string hexvalue)

--- a/KrbRelay/Misc/Helpers.cs
+++ b/KrbRelay/Misc/Helpers.cs
@@ -150,7 +150,7 @@ namespace KrbRelay
         {
             if (length < 0x80)
 
-                return new byte[] { (byte)length };
+                return new[] { (byte)length };
 
             if (length < 0x100)
 

--- a/KrbRelay/Misc/Natives.cs
+++ b/KrbRelay/Misc/Natives.cs
@@ -135,7 +135,7 @@ namespace KrbRelay
         internal static extern void ldap_value_free_len(IntPtr vals);
 
         [DllImport("Wtsapi32.dll")]
-        public static extern bool WTSQuerySessionInformation(IntPtr hServer, int sessionId, WTS_INFO_CLASS wtsInfoClass, out System.IntPtr ppBuffer, out uint pBytesReturned);
+        public static extern bool WTSQuerySessionInformation(IntPtr hServer, int sessionId, WTS_INFO_CLASS wtsInfoClass, out IntPtr ppBuffer, out uint pBytesReturned);
 
         [DllImport("advapi32.dll", EntryPoint = "SystemFunction018", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
         private static extern NTStatus RtlEncryptNtOwfPwdWithNtSesKey([In] byte[] ntOwfPassword, [In] ref byte[] sessionkey, [In, Out] byte[] encryptedNtOwfPassword);

--- a/KrbRelay/Program.cs
+++ b/KrbRelay/Program.cs
@@ -903,7 +903,7 @@ namespace KrbRelay
             //COM object
             Console.WriteLine("[*] Register com server");
             byte[] ba = ComUtils.GetMarshalledObject(new object());
-            COMObjRefStandard std = (COMObjRefStandard)COMObjRefStandard.FromArray(ba);
+            COMObjRefStandard std = (COMObjRefStandard)COMObjRef.FromArray(ba);
             //Console.WriteLine("[*] IPID: {0}", std.Ipid);
             //Console.WriteLine("[*] OXID: {0:X08}", std.Oxid);
             //Console.WriteLine("[*] OID : {0:X08}", std.Oid);

--- a/KrbRelay/Program.cs
+++ b/KrbRelay/Program.cs
@@ -873,7 +873,7 @@ namespace KrbRelay
                 CoInitializeSecurity(IntPtr.Zero, svcs.Length, svcs,
                      IntPtr.Zero, AuthnLevel.RPC_C_AUTHN_LEVEL_DEFAULT,
                      ImpLevel.RPC_C_IMP_LEVEL_IMPERSONATE, IntPtr.Zero,
-                     Natives.EOLE_AUTHENTICATION_CAPABILITIES.EOAC_DYNAMIC_CLOAKING,
+                     EOLE_AUTHENTICATION_CAPABILITIES.EOAC_DYNAMIC_CLOAKING,
                      IntPtr.Zero);
             }
             finally

--- a/KrbRelay/Program.cs
+++ b/KrbRelay/Program.cs
@@ -1,4 +1,4 @@
-using KrbRelay.Clients;
+﻿using KrbRelay.Clients;
 using KrbRelay.Com;
 using NetFwTypeLib;
 using SMBLibrary;
@@ -127,7 +127,7 @@ namespace KrbRelay
                 ticket = Helpers.ConvertApReq(ticket);
                 if(ticket[0] != 0x60)
                 {
-                    Console.WriteLine("[-] Recieved invalid apReq, exploit will fail");
+                    Console.WriteLine("[-] Received invalid apReq, exploit will fail");
                     Console.WriteLine("{0}", Helpers.ByteArrayToString(ticket));
                     Environment.Exit(0);
                 }
@@ -894,7 +894,7 @@ namespace KrbRelay
                 if (port == "-1")
                 {
                     Console.WriteLine("[-] No available ports found");
-                    Console.WriteLine("[-] Firwall will block our COM connection. Exiting");
+                    Console.WriteLine("[-] Firewall will block our COM connection. Exiting");
                     return;
                 }
                 Console.WriteLine("[*] Port {0} available", port);

--- a/KrbRelay/Program.cs
+++ b/KrbRelay/Program.cs
@@ -856,7 +856,7 @@ namespace KrbRelay
             //Console.WriteLine();
             Console.WriteLine("[*] Rewriting PEB");
             //Init RPC server
-            var svcs = new SOLE_AUTHENTICATION_SERVICE[] {
+            var svcs = new[] {
                 new SOLE_AUTHENTICATION_SERVICE() {
                     dwAuthnSvc = 16, // HKLM\SOFTWARE\Microsoft\Rpc\SecurityService sspicli.dll
                     pPrincipalName = spn
@@ -890,7 +890,7 @@ namespace KrbRelay
             if (!checkPort(int.Parse(port)))
             {
                 Console.WriteLine("[*] Looking for available ports..");
-                port = checkPorts(new string[] { "SYSTEM" }).ToString();
+                port = checkPorts(new[] { "SYSTEM" }).ToString();
                 if (port == "-1")
                 {
                     Console.WriteLine("[-] No available ports found");

--- a/KrbRelay/Program.cs
+++ b/KrbRelay/Program.cs
@@ -1,4 +1,4 @@
-﻿using KrbRelay.Clients;
+using KrbRelay.Clients;
 using KrbRelay.Com;
 using NetFwTypeLib;
 using SMBLibrary;
@@ -58,7 +58,7 @@ namespace KrbRelay
             {
                 uint bytesReturned;
                 bool worked;
-                IntPtr buffer = IntPtr.Zero;
+                IntPtr buffer;
 
                 try { 
                     worked = WTSQuerySessionInformation(IntPtr.Zero, SessionId, WTS_INFO_CLASS.ConnectState, out buffer, out bytesReturned);
@@ -87,23 +87,22 @@ namespace KrbRelay
         }
 
         
-        public static SECURITY_HANDLE ldap_phCredential = new SECURITY_HANDLE();
+        public static SECURITY_HANDLE ldap_phCredential;
         public static IntPtr ld = IntPtr.Zero;
-        public static byte[] apRep1 = new byte[] { };
-        public static byte[] apRep2 = new byte[] { };
-        public static byte[] ticket = new byte[] { };
+        public static byte[] apRep1 = { };
+        public static byte[] apRep2 = { };
+        public static byte[] ticket = { };
         public static string spn = "";
         public static string relayedUser = "";
         public static string relayedUserDomain = "";
         public static string domainDN = "";
         public static string targetFQDN = "";
-        public static bool useSSL = false;
+        public static bool useSSL;
         public static bool stopSpoofing = false;
         public static Dictionary<string, string> attacks = new Dictionary<string, string>();
         public static SMB2Client smbClient = new SMB2Client();
         public static HttpClientHandler handler = new HttpClientHandler();
         public static HttpClient httpClient = new HttpClient();
-        public static CookieContainer CookieContainer = new CookieContainer();
 
         //hooked function
         [STAThread]
@@ -650,7 +649,6 @@ namespace KrbRelay
                 return;
             }
 
-
             if (string.IsNullOrEmpty(domain))
             {
                 string[] d = spn.Split('.').Skip(1).ToArray();
@@ -704,7 +702,6 @@ namespace KrbRelay
 
             if (service == "ldap")
             {
-                var ldap_ptsExpiry = new SECURITY_INTEGER();
                 var status = AcquireCredentialsHandle(
                     null,
                     "Negotiate",
@@ -798,7 +795,6 @@ namespace KrbRelay
                 httpClient.BaseAddress = new Uri(string.Format("{0}://{1}", transport, targetFQDN));
                 //Console.WriteLine(httpClient.BaseAddress);
             }
-
 
             if (llmnr)
             {

--- a/KrbRelay/Smb/RPCForSMBLibrary/Services/ScmrService/rChangeServiceConfigWResponse.cs
+++ b/KrbRelay/Smb/RPCForSMBLibrary/Services/ScmrService/rChangeServiceConfigWResponse.cs
@@ -1,5 +1,4 @@
 ﻿using SMBLibrary.RPC;
-using SMBLibrary.Services;
 
 /// <summary>
 /// rChangeServiceConfigW   Response (opnum 11)

--- a/KrbRelay/Smb/SMBLibrary/Authentication/GSSAPI/SPNEGO/DerEncodingHelper.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/GSSAPI/SPNEGO/DerEncodingHelper.cs
@@ -84,13 +84,13 @@ namespace SMBLibrary.Authentication.GSSAPI
         public static byte[] EncodeGeneralString(string value)
         {
             // We do not support character-set designation escape sequences
-            return ASCIIEncoding.ASCII.GetBytes(value);
+            return Encoding.ASCII.GetBytes(value);
         }
 
         public static string DecodeGeneralString(byte[] bytes)
         {
             // We do not support character-set designation escape sequences
-            return ASCIIEncoding.ASCII.GetString(bytes);
+            return Encoding.ASCII.GetString(bytes);
         }
     }
 }

--- a/KrbRelay/Smb/SMBLibrary/Authentication/GSSAPI/SPNEGO/SimpleProtectedNegotiationToken.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/GSSAPI/SPNEGO/SimpleProtectedNegotiationToken.cs
@@ -20,7 +20,7 @@ namespace SMBLibrary.Authentication.GSSAPI
         /// <param name="includeHeader">Prepend the generic GSSAPI header. Required for negTokenInit, optional for negTokenResp.</param>
         public byte[] GetBytes(bool includeHeader)
         {
-            byte[] tokenBytes = this.GetBytes();
+            byte[] tokenBytes = GetBytes();
             if (includeHeader)
             {
                 int objectIdentifierFieldSize = DerEncodingHelper.GetLengthFieldSize(SPNEGOIdentifier.Length);

--- a/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/AVPairUtils.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/AVPairUtils.cs
@@ -16,8 +16,8 @@ namespace SMBLibrary.Authentication.NTLM
         public static KeyValuePairList<AVPairKey, byte[]> GetAVPairSequence(string domainName, string computerName)
         {
             KeyValuePairList<AVPairKey, byte[]> pairs = new KeyValuePairList<AVPairKey, byte[]>();
-            pairs.Add(AVPairKey.NbDomainName, UnicodeEncoding.Unicode.GetBytes(domainName));
-            pairs.Add(AVPairKey.NbComputerName, UnicodeEncoding.Unicode.GetBytes(computerName));
+            pairs.Add(AVPairKey.NbDomainName, Encoding.Unicode.GetBytes(domainName));
+            pairs.Add(AVPairKey.NbComputerName, Encoding.Unicode.GetBytes(computerName));
             return pairs;
         }
 

--- a/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/AuthenticationMessageUtils.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/AuthenticationMessageUtils.cs
@@ -15,13 +15,13 @@ namespace SMBLibrary.Authentication.NTLM
         public static string ReadAnsiStringBufferPointer(byte[] buffer, int offset)
         {
             byte[] bytes = ReadBufferPointer(buffer, offset);
-            return ASCIIEncoding.Default.GetString(bytes);
+            return Encoding.Default.GetString(bytes);
         }
 
         public static string ReadUnicodeStringBufferPointer(byte[] buffer, int offset)
         {
             byte[] bytes = ReadBufferPointer(buffer, offset);
-            return UnicodeEncoding.Unicode.GetString(bytes);
+            return Encoding.Unicode.GetString(bytes);
         }
 
         public static byte[] ReadBufferPointer(byte[] buffer, int offset)

--- a/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Helpers/NTLMCryptography.cs
@@ -131,7 +131,7 @@ namespace SMBLibrary.Authentication.NTLM
         /// </summary>
         public static byte[] LMOWFv1(string password)
         {
-            byte[] plainText = ASCIIEncoding.ASCII.GetBytes("KGS!@#$%");
+            byte[] plainText = Encoding.ASCII.GetBytes("KGS!@#$%");
             byte[] passwordBytes = GetOEMEncoding().GetBytes(password.ToUpper());
             byte[] key = new byte[14];
             Array.Copy(passwordBytes, key, Math.Min(passwordBytes.Length, 14));
@@ -152,7 +152,7 @@ namespace SMBLibrary.Authentication.NTLM
         /// </summary>
         public static byte[] NTOWFv1(string password)
         {
-            byte[] passwordBytes = UnicodeEncoding.Unicode.GetBytes(password);
+            byte[] passwordBytes = Encoding.Unicode.GetBytes(password);
             return new MD4().GetByteHashFromBytes(passwordBytes);
         }
 
@@ -166,10 +166,10 @@ namespace SMBLibrary.Authentication.NTLM
 
         public static byte[] NTOWFv2(string password, string user, string domain)
         {
-            byte[] passwordBytes = UnicodeEncoding.Unicode.GetBytes(password);
+            byte[] passwordBytes = Encoding.Unicode.GetBytes(password);
             byte[] key = new MD4().GetByteHashFromBytes(passwordBytes);
             string text = user.ToUpper() + domain;
-            byte[] bytes = UnicodeEncoding.Unicode.GetBytes(text);
+            byte[] bytes = Encoding.Unicode.GetBytes(text);
             HMACMD5 hmac = new HMACMD5(key);
             return hmac.ComputeHash(bytes, 0, bytes.Length);
         }

--- a/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/IndependentNTLMAuthenticationProvider.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/IndependentNTLMAuthenticationProvider.cs
@@ -185,7 +185,7 @@ namespace SMBLibrary.Authentication.NTLM
 
             if ((message.NegotiateFlags & NegotiateFlags.Anonymous) > 0)
             {
-                if (this.EnableGuestLogin)
+                if (EnableGuestLogin)
                 {
                     authContext.IsGuest = true;
                     return NTStatus.STATUS_SUCCESS;
@@ -204,7 +204,7 @@ namespace SMBLibrary.Authentication.NTLM
             string password = m_GetUserPassword(message.UserName);
             if (password == null)
             {
-                if (this.EnableGuestLogin)
+                if (EnableGuestLogin)
                 {
                     authContext.IsGuest = true;
                     return NTStatus.STATUS_SUCCESS;

--- a/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Structures/NTLMv2ClientChallenge.cs
+++ b/KrbRelay/Smb/SMBLibrary/Authentication/NTLM/Structures/NTLMv2ClientChallenge.cs
@@ -40,8 +40,8 @@ namespace SMBLibrary.Authentication.NTLM
             TimeStamp = timeStamp;
             ClientChallenge = clientChallenge;
             AVPairs = new KeyValuePairList<AVPairKey, byte[]>();
-            AVPairs.Add(AVPairKey.NbDomainName, UnicodeEncoding.Unicode.GetBytes(domainName));
-            AVPairs.Add(AVPairKey.NbComputerName, UnicodeEncoding.Unicode.GetBytes(computerName));
+            AVPairs.Add(AVPairKey.NbDomainName, Encoding.Unicode.GetBytes(domainName));
+            AVPairs.Add(AVPairKey.NbComputerName, Encoding.Unicode.GetBytes(computerName));
         }
 
         public NTLMv2ClientChallenge(DateTime timeStamp, byte[] clientChallenge, KeyValuePairList<AVPairKey, byte[]> targetInfo)

--- a/KrbRelay/Smb/SMBLibrary/Client/SMB2Client.cs
+++ b/KrbRelay/Smb/SMBLibrary/Client/SMB2Client.cs
@@ -304,7 +304,7 @@ namespace SMBLibrary.Client
                 return null;
             }
 
-            List<ShareInfo2Entry> shares = ServerServiceHelper.ListShares(namedPipeShare, m_serverName, SMBLibrary.Services.ShareType.DiskDrive, out status);
+            List<ShareInfo2Entry> shares = ServerServiceHelper.ListShares(namedPipeShare, m_serverName, Services.ShareType.DiskDrive, out status);
             namedPipeShare.Disconnect();
             return shares;
         }
@@ -543,7 +543,7 @@ namespace SMBLibrary.Client
 
         private void Log(string message)
         {
-            System.Diagnostics.Debug.Print(message);
+            Debug.Print(message);
         }
 
         internal void TrySendCommand(SMB2Command request)

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileInformation/FileInformation.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileInformation/FileInformation.cs
@@ -15,7 +15,7 @@ namespace SMBLibrary
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             WriteBytes(buffer, 0);
             return buffer;
         }

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileInformation/Query/FileStreamEntry.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileInformation/Query/FileStreamEntry.cs
@@ -61,7 +61,7 @@ namespace SMBLibrary
         {
             get
             {
-                int length = this.Length;
+                int length = Length;
                 int padding = (8 - (length % 8)) % 8;
                 return length + padding;
             }

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileSystemInformation/FileSystemInformation.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/FileSystemInformation/FileSystemInformation.cs
@@ -13,7 +13,7 @@ namespace SMBLibrary
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             WriteBytes(buffer, 0);
             return buffer;
         }

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/IOCtl/PipeWaitRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/IOCtl/PipeWaitRequest.cs
@@ -38,7 +38,7 @@ namespace SMBLibrary
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             LittleEndianWriter.WriteUInt64(buffer, 0, Timeout);
             LittleEndianWriter.WriteUInt32(buffer, 8, (uint)(Name.Length * 2));
             ByteWriter.WriteByte(buffer, 12, Convert.ToByte(TimeSpecified));

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/AccessAllowedACE.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACE/AccessAllowedACE.cs
@@ -35,7 +35,7 @@ namespace SMBLibrary
 
         public override void WriteBytes(byte[] buffer, ref int offset)
         {
-            Header.AceSize = (ushort)this.Length;
+            Header.AceSize = (ushort)Length;
             Header.WriteBytes(buffer, ref offset);
             LittleEndianWriter.WriteUInt32(buffer, ref offset, (uint)Mask);
             Sid.WriteBytes(buffer, ref offset);

--- a/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACL.cs
+++ b/KrbRelay/Smb/SMBLibrary/NTFileStore/Structures/SecurityInformation/ACL.cs
@@ -41,7 +41,7 @@ namespace SMBLibrary
             for (int index = 0; index < aceCount; index++)
             {
                 ACE ace = ACE.GetAce(buffer, offset);
-                this.Add(ace);
+                Add(ace);
                 offset += ace.Length;
             }
         }

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/NegativeSessionResponsePacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/NegativeSessionResponsePacket.cs
@@ -18,18 +18,18 @@ namespace SMBLibrary.NetBios
 
         public NegativeSessionResponsePacket() : base()
         {
-            this.Type = SessionPacketTypeName.NegativeSessionResponse;
+            Type = SessionPacketTypeName.NegativeSessionResponse;
         }
 
         public NegativeSessionResponsePacket(byte[] buffer, int offset) : base(buffer, offset)
         {
-            ErrorCode = ByteReader.ReadByte(this.Trailer, offset + 0);
+            ErrorCode = ByteReader.ReadByte(Trailer, offset + 0);
         }
 
         public override byte[] GetBytes()
         {
-            this.Trailer = new byte[1];
-            this.Trailer[0] = ErrorCode;
+            Trailer = new byte[1];
+            Trailer[0] = ErrorCode;
 
             return base.GetBytes();
         }

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/PositiveSessionResponsePacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/PositiveSessionResponsePacket.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary.NetBios
     {
         public PositiveSessionResponsePacket() : base()
         {
-            this.Type = SessionPacketTypeName.PositiveSessionResponse;
+            Type = SessionPacketTypeName.PositiveSessionResponse;
         }
 
         public PositiveSessionResponsePacket(byte[] buffer, int offset) : base(buffer, offset)
@@ -23,7 +23,7 @@ namespace SMBLibrary.NetBios
 
         public override byte[] GetBytes()
         {
-            this.Trailer = new byte[0];
+            Trailer = new byte[0];
             return base.GetBytes();
         }
 

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionKeepAlivePacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionKeepAlivePacket.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary.NetBios
     {
         public SessionKeepAlivePacket()
         {
-            this.Type = SessionPacketTypeName.SessionKeepAlive;
+            Type = SessionPacketTypeName.SessionKeepAlive;
         }
 
         public SessionKeepAlivePacket(byte[] buffer, int offset) : base(buffer, offset)
@@ -23,7 +23,7 @@ namespace SMBLibrary.NetBios
 
         public override byte[] GetBytes()
         {
-            this.Trailer = new byte[0];
+            Trailer = new byte[0];
             return base.GetBytes();
         }
 

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionMessagePacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionMessagePacket.cs
@@ -14,7 +14,7 @@ namespace SMBLibrary.NetBios
     {
         public SessionMessagePacket() : base()
         {
-            this.Type = SessionPacketTypeName.SessionMessage;
+            Type = SessionPacketTypeName.SessionMessage;
         }
 
         public SessionMessagePacket(byte[] buffer, int offset) : base(buffer, offset)

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionPacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionPacket.cs
@@ -41,7 +41,7 @@ namespace SMBLibrary.NetBios
 
         public virtual byte[] GetBytes()
         {
-            TrailerLength = this.Trailer.Length;
+            TrailerLength = Trailer.Length;
 
             byte flags = Convert.ToByte(TrailerLength >> 16);
 

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionRequestPacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionRequestPacket.cs
@@ -20,22 +20,22 @@ namespace SMBLibrary.NetBios
 
         public SessionRequestPacket()
         {
-            this.Type = SessionPacketTypeName.SessionRequest;
+            Type = SessionPacketTypeName.SessionRequest;
         }
 
         public SessionRequestPacket(byte[] buffer, int offset) : base(buffer, offset)
         {
-            CalledName = NetBiosUtils.DecodeName(this.Trailer, ref offset);
-            CallingName = NetBiosUtils.DecodeName(this.Trailer, ref offset);
+            CalledName = NetBiosUtils.DecodeName(Trailer, ref offset);
+            CallingName = NetBiosUtils.DecodeName(Trailer, ref offset);
         }
 
         public override byte[] GetBytes()
         {
             byte[] part1 = NetBiosUtils.EncodeName(CalledName, String.Empty);
             byte[] part2 = NetBiosUtils.EncodeName(CallingName, String.Empty);
-            this.Trailer = new byte[part1.Length + part2.Length];
-            ByteWriter.WriteBytes(this.Trailer, 0, part1);
-            ByteWriter.WriteBytes(this.Trailer, part1.Length, part2);
+            Trailer = new byte[part1.Length + part2.Length];
+            ByteWriter.WriteBytes(Trailer, 0, part1);
+            ByteWriter.WriteBytes(Trailer, part1.Length, part2);
             return base.GetBytes();
         }
 

--- a/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionRetargetResponsePacket.cs
+++ b/KrbRelay/Smb/SMBLibrary/NetBios/SessionPackets/SessionRetargetResponsePacket.cs
@@ -19,20 +19,20 @@ namespace SMBLibrary.NetBios
 
         public SessionRetargetResponsePacket() : base()
         {
-            this.Type = SessionPacketTypeName.RetargetSessionResponse;
+            Type = SessionPacketTypeName.RetargetSessionResponse;
         }
 
         public SessionRetargetResponsePacket(byte[] buffer, int offset) : base(buffer, offset)
         {
-            IPAddress = BigEndianConverter.ToUInt32(this.Trailer, offset + 0);
-            Port = BigEndianConverter.ToUInt16(this.Trailer, offset + 4);
+            IPAddress = BigEndianConverter.ToUInt32(Trailer, offset + 0);
+            Port = BigEndianConverter.ToUInt16(Trailer, offset + 4);
         }
 
         public override byte[] GetBytes()
         {
-            this.Trailer = new byte[6];
-            BigEndianWriter.WriteUInt32(this.Trailer, 0, IPAddress);
-            BigEndianWriter.WriteUInt16(this.Trailer, 4, Port);
+            Trailer = new byte[6];
+            BigEndianWriter.WriteUInt32(Trailer, 0, IPAddress);
+            BigEndianWriter.WriteUInt16(Trailer, 4, Port);
             return base.GetBytes();
         }
 

--- a/KrbRelay/Smb/SMBLibrary/RPC/NDR/NDRConformantArray.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/NDR/NDRConformantArray.cs
@@ -23,7 +23,7 @@ namespace SMBLibrary.RPC
             {
                 T entry = new T();
                 entry.Read(parser);
-                this.Add(entry);
+                Add(entry);
             }
 
             parser.EndStructure();
@@ -32,9 +32,9 @@ namespace SMBLibrary.RPC
         public void Write(NDRWriter writer)
         {
             writer.BeginStructure();
-            uint maxCount = (uint)this.Count;
+            uint maxCount = (uint)Count;
             writer.WriteUInt32(maxCount);
-            for (int index = 0; index < this.Count; index++)
+            for (int index = 0; index < Count; index++)
             {
                 this[index].Write(writer);
             }

--- a/KrbRelay/Smb/SMBLibrary/RPC/NDR/NDRUnicodeString.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/NDR/NDRUnicodeString.cs
@@ -48,7 +48,7 @@ namespace SMBLibrary.RPC
             {
                 builder.Append((char)parser.ReadUInt16());
             }
-            this.Value = builder.ToString().TrimEnd('\0');
+            Value = builder.ToString().TrimEnd('\0');
         }
 
         public void Write(NDRWriter writer)

--- a/KrbRelay/Smb/SMBLibrary/RPC/Structures/ContextList.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/Structures/ContextList.cs
@@ -34,14 +34,14 @@ namespace SMBLibrary.RPC
             for (int index = 0; index < numberOfContextElements; index++)
             {
                 ContextElement element = new ContextElement(buffer, offset);
-                this.Add(element);
+                Add(element);
                 offset += element.Length;
             }
         }
 
         public void WriteBytes(byte[] buffer, int offset)
         {
-            byte numberOfContextElements = (byte)this.Count;
+            byte numberOfContextElements = (byte)Count;
 
             ByteWriter.WriteByte(buffer, offset + 0, numberOfContextElements);
             ByteWriter.WriteByte(buffer, offset + 1, Reserved1);
@@ -57,7 +57,7 @@ namespace SMBLibrary.RPC
         public void WriteBytes(byte[] buffer, ref int offset)
         {
             WriteBytes(buffer, offset);
-            offset += this.Length;
+            offset += Length;
         }
 
         public int Length
@@ -65,7 +65,7 @@ namespace SMBLibrary.RPC
             get
             {
                 int length = 4;
-                for (int index = 0; index < this.Count; index++)
+                for (int index = 0; index < Count; index++)
                 {
                     length += this[index].Length;
                 }

--- a/KrbRelay/Smb/SMBLibrary/RPC/Structures/ResultList.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/Structures/ResultList.cs
@@ -32,14 +32,14 @@ namespace SMBLibrary.RPC
             for (int index = 0; index < numberOfResults; index++)
             {
                 ResultElement element = new ResultElement(buffer, offset);
-                this.Add(element);
+                Add(element);
                 offset += ResultElement.Length;
             }
         }
 
         public void WriteBytes(byte[] buffer, int offset)
         {
-            byte numberOfResults = (byte)this.Count;
+            byte numberOfResults = (byte)Count;
 
             ByteWriter.WriteByte(buffer, offset + 0, numberOfResults);
             ByteWriter.WriteByte(buffer, offset + 1, Reserved);
@@ -55,14 +55,14 @@ namespace SMBLibrary.RPC
         public void WriteBytes(byte[] buffer, ref int offset)
         {
             WriteBytes(buffer, offset);
-            offset += this.Length;
+            offset += Length;
         }
 
         public int Length
         {
             get
             {
-                return 4 + ResultElement.Length * this.Count;
+                return 4 + ResultElement.Length * Count;
             }
         }
     }

--- a/KrbRelay/Smb/SMBLibrary/RPC/Structures/SyntaxID.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/Structures/SyntaxID.cs
@@ -42,7 +42,7 @@ namespace SMBLibrary.RPC
         {
             if (obj is SyntaxID)
             {
-                return this.InterfaceUUID.Equals(((SyntaxID)obj).InterfaceUUID) && this.InterfaceVersion.Equals(((SyntaxID)obj).InterfaceVersion);
+                return InterfaceUUID.Equals(((SyntaxID)obj).InterfaceUUID) && InterfaceVersion.Equals(((SyntaxID)obj).InterfaceVersion);
             }
             return false;
         }

--- a/KrbRelay/Smb/SMBLibrary/RPC/Structures/VersionsSupported.cs
+++ b/KrbRelay/Smb/SMBLibrary/RPC/Structures/VersionsSupported.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.RPC
 
         public void WriteBytes(byte[] buffer, int offset)
         {
-            ByteWriter.WriteByte(buffer, offset + 0, (byte)this.Count);
+            ByteWriter.WriteByte(buffer, offset + 0, (byte)Count);
             for (int index = 0; index < Entries.Count; index++)
             {
                 Entries[index].WriteBytes(buffer, offset + 1 + index * Version.Length);

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CheckDirectoryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CheckDirectoryRequest.cs
@@ -31,12 +31,12 @@ namespace SMBLibrary.SMB1
 
         public CheckDirectoryRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            DirectoryName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            DirectoryName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -50,9 +50,9 @@ namespace SMBLibrary.SMB1
             {
                 length += DirectoryName.Length + 1;
             }
-            this.SMBData = new byte[1 + length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            SMB1Helper.WriteSMBString(this.SMBData, 1, isUnicode, DirectoryName);
+            SMBData = new byte[1 + length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            SMB1Helper.WriteSMBString(SMBData, 1, isUnicode, DirectoryName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CloseRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CloseRequest.cs
@@ -31,15 +31,15 @@ namespace SMBLibrary.SMB1
 
         public CloseRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            LastTimeModified = UTimeHelper.ReadNullableUTime(this.SMBParameters, 2);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            LastTimeModified = UTimeHelper.ReadNullableUTime(SMBParameters, 2);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, FID);
-            UTimeHelper.WriteUTime(this.SMBParameters, 2, LastTimeModified);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, FID);
+            UTimeHelper.WriteUTime(SMBParameters, 2, LastTimeModified);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CreateDirectoryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/CreateDirectoryRequest.cs
@@ -33,12 +33,12 @@ namespace SMBLibrary.SMB1
 
         public CreateDirectoryRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            DirectoryName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            DirectoryName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -52,9 +52,9 @@ namespace SMBLibrary.SMB1
             {
                 length += DirectoryName.Length + 1;
             }
-            this.SMBData = new byte[1 + length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            SMB1Helper.WriteSMBString(this.SMBData, 1, isUnicode, DirectoryName);
+            SMBData = new byte[1 + length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            SMB1Helper.WriteSMBString(SMBData, 1, isUnicode, DirectoryName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/DeleteDirectoryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/DeleteDirectoryRequest.cs
@@ -29,12 +29,12 @@ namespace SMBLibrary.SMB1
 
         public DeleteDirectoryRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            DirectoryName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            DirectoryName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -48,9 +48,9 @@ namespace SMBLibrary.SMB1
             {
                 length += DirectoryName.Length + 1;
             }
-            this.SMBData = new byte[length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            SMB1Helper.WriteSMBString(this.SMBData, 1, isUnicode, DirectoryName);
+            SMBData = new byte[length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            SMB1Helper.WriteSMBString(SMBData, 1, isUnicode, DirectoryName);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/DeleteRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/DeleteRequest.cs
@@ -34,14 +34,14 @@ namespace SMBLibrary.SMB1
 
         public DeleteRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            SearchAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            SearchAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(SMBParameters, 0);
 
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            FileName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            FileName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/EchoRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/EchoRequest.cs
@@ -25,13 +25,13 @@ namespace SMBLibrary.SMB1
 
         public EchoRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            EchoCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            EchoCount = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, EchoCount);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, EchoCount);
 
             return base.GetBytes(isUnicode);
         }
@@ -40,11 +40,11 @@ namespace SMBLibrary.SMB1
         {
             get
             {
-                return this.SMBData;
+                return SMBData;
             }
             set
             {
-                this.SMBData = value;
+                SMBData = value;
             }
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/EchoResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/EchoResponse.cs
@@ -25,13 +25,13 @@ namespace SMBLibrary.SMB1
 
         public EchoResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            SequenceNumber = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            SequenceNumber = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, SequenceNumber);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, SequenceNumber);
 
             return base.GetBytes(isUnicode);
         }
@@ -40,11 +40,11 @@ namespace SMBLibrary.SMB1
         {
             get
             {
-                return this.SMBData;
+                return SMBData;
             }
             set
             {
-                this.SMBData = value;
+                SMBData = value;
             }
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/FindClose2Request.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/FindClose2Request.cs
@@ -18,7 +18,7 @@ namespace SMBLibrary.SMB1
 
         public FindClose2Request(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            SearchHandle = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            SearchHandle = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override CommandName CommandName

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/FlushRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/FlushRequest.cs
@@ -25,13 +25,13 @@ namespace SMBLibrary.SMB1
 
         public FlushRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, FID);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, FID);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LockingAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LockingAndXRequest.cs
@@ -26,17 +26,17 @@ namespace SMBLibrary.SMB1
 
         public void Write32(byte[] buffer, ref int offset)
         {
-            LittleEndianWriter.WriteUInt16(buffer, ref offset, this.PID);
-            LittleEndianWriter.WriteUInt32(buffer, ref offset, (uint)this.ByteOffset);
-            LittleEndianWriter.WriteUInt32(buffer, ref offset, (uint)this.LengthInBytes);
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, PID);
+            LittleEndianWriter.WriteUInt32(buffer, ref offset, (uint)ByteOffset);
+            LittleEndianWriter.WriteUInt32(buffer, ref offset, (uint)LengthInBytes);
         }
 
         public void Write64(byte[] buffer, ref int offset)
         {
-            LittleEndianWriter.WriteUInt16(buffer, ref offset, this.PID);
+            LittleEndianWriter.WriteUInt16(buffer, ref offset, PID);
             offset += 2; // padding
-            LittleEndianWriter.WriteUInt64(buffer, ref offset, this.ByteOffset);
-            LittleEndianWriter.WriteUInt64(buffer, ref offset, this.LengthInBytes);
+            LittleEndianWriter.WriteUInt64(buffer, ref offset, ByteOffset);
+            LittleEndianWriter.WriteUInt64(buffer, ref offset, LengthInBytes);
         }
 
         public static LockingRange Read32(byte[] buffer, ref int offset)
@@ -86,25 +86,25 @@ namespace SMBLibrary.SMB1
 
         public LockingAndXRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            TypeOfLock = (LockType)ByteReader.ReadByte(this.SMBParameters, 6);
-            NewOpLockLevel = ByteReader.ReadByte(this.SMBParameters, 7);
-            Timeout = LittleEndianConverter.ToUInt32(this.SMBParameters, 8);
-            ushort numberOfRequestedUnlocks = LittleEndianConverter.ToUInt16(this.SMBParameters, 12);
-            ushort numberOfRequestedLocks = LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            TypeOfLock = (LockType)ByteReader.ReadByte(SMBParameters, 6);
+            NewOpLockLevel = ByteReader.ReadByte(SMBParameters, 7);
+            Timeout = LittleEndianConverter.ToUInt32(SMBParameters, 8);
+            ushort numberOfRequestedUnlocks = LittleEndianConverter.ToUInt16(SMBParameters, 12);
+            ushort numberOfRequestedLocks = LittleEndianConverter.ToUInt16(SMBParameters, 14);
 
             int dataOffset = 0;
             if ((TypeOfLock & LockType.LARGE_FILES) > 0)
             {
                 for (int index = 0; index < numberOfRequestedUnlocks; index++)
                 {
-                    LockingRange entry = LockingRange.Read64(this.SMBData, ref dataOffset);
+                    LockingRange entry = LockingRange.Read64(SMBData, ref dataOffset);
                     Unlocks.Add(entry);
                 }
 
                 for (int index = 0; index < numberOfRequestedLocks; index++)
                 {
-                    LockingRange entry = LockingRange.Read64(this.SMBData, ref dataOffset);
+                    LockingRange entry = LockingRange.Read64(SMBData, ref dataOffset);
                     Locks.Add(entry);
                 }
             }
@@ -112,13 +112,13 @@ namespace SMBLibrary.SMB1
             {
                 for (int index = 0; index < numberOfRequestedUnlocks; index++)
                 {
-                    LockingRange entry = LockingRange.Read32(this.SMBData, ref dataOffset);
+                    LockingRange entry = LockingRange.Read32(SMBData, ref dataOffset);
                     Unlocks.Add(entry);
                 }
 
                 for (int index = 0; index < numberOfRequestedLocks; index++)
                 {
-                    LockingRange entry = LockingRange.Read32(this.SMBData, ref dataOffset);
+                    LockingRange entry = LockingRange.Read32(SMBData, ref dataOffset);
                     Locks.Add(entry);
                 }
             }
@@ -126,13 +126,13 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, FID);
-            ByteWriter.WriteByte(this.SMBParameters, 6, (byte)TypeOfLock);
-            ByteWriter.WriteByte(this.SMBParameters, 7, NewOpLockLevel);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 8, Timeout);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, (ushort)Unlocks.Count);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, (ushort)Locks.Count);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, FID);
+            ByteWriter.WriteByte(SMBParameters, 6, (byte)TypeOfLock);
+            ByteWriter.WriteByte(SMBParameters, 7, NewOpLockLevel);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 8, Timeout);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, (ushort)Unlocks.Count);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, (ushort)Locks.Count);
 
             int dataLength;
             bool isLargeFile = (TypeOfLock & LockType.LARGE_FILES) > 0;
@@ -145,16 +145,16 @@ namespace SMBLibrary.SMB1
                 dataLength = (Unlocks.Count + Locks.Count) * LockingRange.Length32;
             }
             int dataOffset = 0;
-            this.SMBData = new byte[dataLength];
+            SMBData = new byte[dataLength];
             for (int index = 0; index < Unlocks.Count; index++)
             {
                 if (isLargeFile)
                 {
-                    Unlocks[index].Write64(this.SMBData, ref dataOffset);
+                    Unlocks[index].Write64(SMBData, ref dataOffset);
                 }
                 else
                 {
-                    Unlocks[index].Write32(this.SMBData, ref dataOffset);
+                    Unlocks[index].Write32(SMBData, ref dataOffset);
                 }
             }
 
@@ -162,11 +162,11 @@ namespace SMBLibrary.SMB1
             {
                 if (isLargeFile)
                 {
-                    Locks[index].Write64(this.SMBData, ref dataOffset);
+                    Locks[index].Write64(SMBData, ref dataOffset);
                 }
                 else
                 {
-                    Locks[index].Write32(this.SMBData, ref dataOffset);
+                    Locks[index].Write32(SMBData, ref dataOffset);
                 }
             }
             return base.GetBytes(isUnicode);

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LockingAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LockingAndXResponse.cs
@@ -24,7 +24,7 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LogoffAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LogoffAndXRequest.cs
@@ -24,7 +24,7 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LogoffAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/LogoffAndXResponse.cs
@@ -24,7 +24,7 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXRequest.cs
@@ -44,18 +44,18 @@ namespace SMBLibrary.SMB1
 
         public NTCreateAndXRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            Reserved = ByteReader.ReadByte(this.SMBParameters, 4);
-            ushort nameLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 5);
-            Flags = (NTCreateFlags)LittleEndianConverter.ToUInt32(this.SMBParameters, 7);
-            RootDirectoryFID = LittleEndianConverter.ToUInt32(this.SMBParameters, 11);
-            DesiredAccess = (AccessMask)LittleEndianConverter.ToUInt32(this.SMBParameters, 15);
-            AllocationSize = LittleEndianConverter.ToInt64(this.SMBParameters, 19);
-            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianConverter.ToUInt32(this.SMBParameters, 27);
-            ShareAccess = (ShareAccess)LittleEndianConverter.ToUInt32(this.SMBParameters, 31);
-            CreateDisposition = (CreateDisposition)LittleEndianConverter.ToUInt32(this.SMBParameters, 35);
-            CreateOptions = (CreateOptions)LittleEndianConverter.ToUInt32(this.SMBParameters, 39);
-            ImpersonationLevel = (ImpersonationLevel)LittleEndianConverter.ToUInt32(this.SMBParameters, 43);
-            SecurityFlags = (SecurityFlags)ByteReader.ReadByte(this.SMBParameters, 47);
+            Reserved = ByteReader.ReadByte(SMBParameters, 4);
+            ushort nameLength = LittleEndianConverter.ToUInt16(SMBParameters, 5);
+            Flags = (NTCreateFlags)LittleEndianConverter.ToUInt32(SMBParameters, 7);
+            RootDirectoryFID = LittleEndianConverter.ToUInt32(SMBParameters, 11);
+            DesiredAccess = (AccessMask)LittleEndianConverter.ToUInt32(SMBParameters, 15);
+            AllocationSize = LittleEndianConverter.ToInt64(SMBParameters, 19);
+            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianConverter.ToUInt32(SMBParameters, 27);
+            ShareAccess = (ShareAccess)LittleEndianConverter.ToUInt32(SMBParameters, 31);
+            CreateDisposition = (CreateDisposition)LittleEndianConverter.ToUInt32(SMBParameters, 35);
+            CreateOptions = (CreateOptions)LittleEndianConverter.ToUInt32(SMBParameters, 39);
+            ImpersonationLevel = (ImpersonationLevel)LittleEndianConverter.ToUInt32(SMBParameters, 43);
+            SecurityFlags = (SecurityFlags)ByteReader.ReadByte(SMBParameters, 47);
 
             int dataOffset = 0;
             if (isUnicode)
@@ -64,7 +64,7 @@ namespace SMBLibrary.SMB1
                 // Note: SMBData starts at an odd offset.
                 dataOffset = 1;
             }
-            FileName = SMB1Helper.ReadSMBString(this.SMBData, dataOffset, isUnicode);
+            FileName = SMB1Helper.ReadSMBString(SMBData, dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -74,31 +74,31 @@ namespace SMBLibrary.SMB1
             {
                 nameLength *= 2;
             }
-            this.SMBParameters = new byte[ParametersLength];
-            ByteWriter.WriteByte(this.SMBParameters, 4, Reserved);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 5, nameLength);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 7, (uint)Flags);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 11, RootDirectoryFID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 15, (uint)DesiredAccess);
-            LittleEndianWriter.WriteInt64(this.SMBParameters, 19, AllocationSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 27, (uint)ExtFileAttributes);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 31, (uint)ShareAccess);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 35, (uint)CreateDisposition);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 39, (uint)CreateOptions);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 43, (uint)ImpersonationLevel);
-            ByteWriter.WriteByte(this.SMBParameters, 47, (byte)SecurityFlags);
+            SMBParameters = new byte[ParametersLength];
+            ByteWriter.WriteByte(SMBParameters, 4, Reserved);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 5, nameLength);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 7, (uint)Flags);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 11, RootDirectoryFID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 15, (uint)DesiredAccess);
+            LittleEndianWriter.WriteInt64(SMBParameters, 19, AllocationSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 27, (uint)ExtFileAttributes);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 31, (uint)ShareAccess);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 35, (uint)CreateDisposition);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 39, (uint)CreateOptions);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 43, (uint)ImpersonationLevel);
+            ByteWriter.WriteByte(SMBParameters, 47, (byte)SecurityFlags);
 
             int padding = 0;
             if (isUnicode)
             {
                 padding = 1;
-                this.SMBData = new byte[padding + FileName.Length * 2 + 2];
+                SMBData = new byte[padding + FileName.Length * 2 + 2];
             }
             else
             {
-                this.SMBData = new byte[FileName.Length + 1];
+                SMBData = new byte[FileName.Length + 1];
             }
-            SMB1Helper.WriteSMBString(this.SMBData, padding, isUnicode, FileName);
+            SMB1Helper.WriteSMBString(SMBData, padding, isUnicode, FileName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXResponse.cs
@@ -43,38 +43,38 @@ namespace SMBLibrary.SMB1
         public NTCreateAndXResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int parametersOffset = 4;
-            OpLockLevel = (OpLockLevel)ByteReader.ReadByte(this.SMBParameters, ref parametersOffset);
-            FID = LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            CreateDisposition = (CreateDisposition)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            CreateTime = SMB1Helper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastAccessTime = SMB1Helper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastWriteTime = SMB1Helper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastChangeTime = SMB1Helper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            AllocationSize = LittleEndianReader.ReadInt64(this.SMBParameters, ref parametersOffset);
-            EndOfFile = LittleEndianReader.ReadInt64(this.SMBParameters, ref parametersOffset);
-            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            NMPipeStatus = NamedPipeStatus.Read(this.SMBParameters, ref parametersOffset);
-            Directory = (ByteReader.ReadByte(this.SMBParameters, ref parametersOffset) > 0);
+            OpLockLevel = (OpLockLevel)ByteReader.ReadByte(SMBParameters, ref parametersOffset);
+            FID = LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            CreateDisposition = (CreateDisposition)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            CreateTime = SMB1Helper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastAccessTime = SMB1Helper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastWriteTime = SMB1Helper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastChangeTime = SMB1Helper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            AllocationSize = LittleEndianReader.ReadInt64(SMBParameters, ref parametersOffset);
+            EndOfFile = LittleEndianReader.ReadInt64(SMBParameters, ref parametersOffset);
+            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            NMPipeStatus = NamedPipeStatus.Read(SMBParameters, ref parametersOffset);
+            Directory = (ByteReader.ReadByte(SMBParameters, ref parametersOffset) > 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            ByteWriter.WriteByte(this.SMBParameters, ref parametersOffset, (byte)OpLockLevel);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, FID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)CreateDisposition);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, CreateTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastAccessTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastWriteTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastChangeTime);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)ExtFileAttributes);
-            LittleEndianWriter.WriteInt64(this.SMBParameters, ref parametersOffset, AllocationSize);
-            LittleEndianWriter.WriteInt64(this.SMBParameters, ref parametersOffset, EndOfFile);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)ResourceType);
-            NMPipeStatus.WriteBytes(this.SMBParameters, ref parametersOffset);
-            ByteWriter.WriteByte(this.SMBParameters, ref parametersOffset, Convert.ToByte(Directory));
+            ByteWriter.WriteByte(SMBParameters, ref parametersOffset, (byte)OpLockLevel);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, FID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)CreateDisposition);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, CreateTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastAccessTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastWriteTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastChangeTime);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)ExtFileAttributes);
+            LittleEndianWriter.WriteInt64(SMBParameters, ref parametersOffset, AllocationSize);
+            LittleEndianWriter.WriteInt64(SMBParameters, ref parametersOffset, EndOfFile);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)ResourceType);
+            NMPipeStatus.WriteBytes(SMBParameters, ref parametersOffset);
+            ByteWriter.WriteByte(SMBParameters, ref parametersOffset, Convert.ToByte(Directory));
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXResponseExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTCreateAndXResponseExtended.cs
@@ -51,46 +51,46 @@ namespace SMBLibrary.SMB1
         public NTCreateAndXResponseExtended(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int parametersOffset = 4;
-            OpLockLevel = (OpLockLevel)ByteReader.ReadByte(this.SMBParameters, ref parametersOffset);
-            FID = LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            CreateDisposition = (CreateDisposition)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            CreateTime = FileTimeHelper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastAccessTime = FileTimeHelper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastWriteTime = FileTimeHelper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            LastChangeTime = FileTimeHelper.ReadNullableFileTime(this.SMBParameters, ref parametersOffset);
-            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            AllocationSize = LittleEndianReader.ReadInt64(this.SMBParameters, ref parametersOffset);
-            EndOfFile = LittleEndianReader.ReadInt64(this.SMBParameters, ref parametersOffset);
-            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            NMPipeStatus_or_FileStatusFlags = LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            Directory = (ByteReader.ReadByte(this.SMBParameters, ref parametersOffset) > 0);
-            VolumeGuid = LittleEndianReader.ReadGuid(this.SMBParameters, ref parametersOffset);
-            FileID = LittleEndianReader.ReadUInt64(this.SMBParameters, ref parametersOffset);
-            MaximalAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            GuestMaximalAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
+            OpLockLevel = (OpLockLevel)ByteReader.ReadByte(SMBParameters, ref parametersOffset);
+            FID = LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            CreateDisposition = (CreateDisposition)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            CreateTime = FileTimeHelper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastAccessTime = FileTimeHelper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastWriteTime = FileTimeHelper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            LastChangeTime = FileTimeHelper.ReadNullableFileTime(SMBParameters, ref parametersOffset);
+            ExtFileAttributes = (ExtendedFileAttributes)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            AllocationSize = LittleEndianReader.ReadInt64(SMBParameters, ref parametersOffset);
+            EndOfFile = LittleEndianReader.ReadInt64(SMBParameters, ref parametersOffset);
+            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            NMPipeStatus_or_FileStatusFlags = LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            Directory = (ByteReader.ReadByte(SMBParameters, ref parametersOffset) > 0);
+            VolumeGuid = LittleEndianReader.ReadGuid(SMBParameters, ref parametersOffset);
+            FileID = LittleEndianReader.ReadUInt64(SMBParameters, ref parametersOffset);
+            MaximalAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            GuestMaximalAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            ByteWriter.WriteByte(this.SMBParameters, ref parametersOffset, (byte)OpLockLevel);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, FID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)CreateDisposition);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, CreateTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastAccessTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastWriteTime);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, ref parametersOffset, LastChangeTime);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)ExtFileAttributes);
-            LittleEndianWriter.WriteInt64(this.SMBParameters, ref parametersOffset, AllocationSize);
-            LittleEndianWriter.WriteInt64(this.SMBParameters, ref parametersOffset, EndOfFile);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)ResourceType);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, NMPipeStatus_or_FileStatusFlags);
-            ByteWriter.WriteByte(this.SMBParameters, ref parametersOffset, Convert.ToByte(Directory));
-            LittleEndianWriter.WriteGuid(this.SMBParameters, ref parametersOffset, VolumeGuid);
-            LittleEndianWriter.WriteUInt64(this.SMBParameters, ref parametersOffset, FileID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)MaximalAccessRights);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)GuestMaximalAccessRights);
+            ByteWriter.WriteByte(SMBParameters, ref parametersOffset, (byte)OpLockLevel);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, FID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)CreateDisposition);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, CreateTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastAccessTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastWriteTime);
+            FileTimeHelper.WriteFileTime(SMBParameters, ref parametersOffset, LastChangeTime);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)ExtFileAttributes);
+            LittleEndianWriter.WriteInt64(SMBParameters, ref parametersOffset, AllocationSize);
+            LittleEndianWriter.WriteInt64(SMBParameters, ref parametersOffset, EndOfFile);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)ResourceType);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, NMPipeStatus_or_FileStatusFlags);
+            ByteWriter.WriteByte(SMBParameters, ref parametersOffset, Convert.ToByte(Directory));
+            LittleEndianWriter.WriteGuid(SMBParameters, ref parametersOffset, VolumeGuid);
+            LittleEndianWriter.WriteUInt64(SMBParameters, ref parametersOffset, FileID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)MaximalAccessRights);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)GuestMaximalAccessRights);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactRequest.cs
@@ -48,19 +48,19 @@ namespace SMBLibrary.SMB1
         public NTTransactRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int readOffset = 0;
-            MaxSetupCount = ByteReader.ReadByte(this.SMBParameters, ref readOffset);
-            Reserved1 = LittleEndianReader.ReadUInt16(this.SMBParameters, ref readOffset);
-            TotalParameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            TotalDataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            MaxParameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            MaxDataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            byte setupCount = ByteReader.ReadByte(this.SMBParameters, ref readOffset);
-            Function = (NTTransactSubcommandName)LittleEndianReader.ReadUInt16(this.SMBParameters, ref readOffset);
-            Setup = ByteReader.ReadBytes(this.SMBParameters, ref readOffset, setupCount * 2);
+            MaxSetupCount = ByteReader.ReadByte(SMBParameters, ref readOffset);
+            Reserved1 = LittleEndianReader.ReadUInt16(SMBParameters, ref readOffset);
+            TotalParameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            TotalDataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            MaxParameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            MaxDataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            byte setupCount = ByteReader.ReadByte(SMBParameters, ref readOffset);
+            Function = (NTTransactSubcommandName)LittleEndianReader.ReadUInt16(SMBParameters, ref readOffset);
+            Setup = ByteReader.ReadBytes(SMBParameters, ref readOffset, setupCount * 2);
 
             TransParameters = ByteReader.ReadBytes(buffer, (int)parameterOffset, (int)parameterCount);
             TransData = ByteReader.ReadBytes(buffer, (int)dataOffset, (int)dataCount);
@@ -80,25 +80,25 @@ namespace SMBLibrary.SMB1
             int padding2 = (int)(4 - (dataOffset % 4)) % 4;
             dataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
+            SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
             int writeOffset = 0;
-            ByteWriter.WriteByte(this.SMBParameters, ref writeOffset, MaxSetupCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref writeOffset, Reserved1);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalParameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalDataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, MaxParameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, MaxDataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataOffset);
-            ByteWriter.WriteByte(this.SMBParameters, ref writeOffset, setupCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref writeOffset, (ushort)Function);
-            ByteWriter.WriteBytes(this.SMBParameters, ref writeOffset, Setup);
+            ByteWriter.WriteByte(SMBParameters, ref writeOffset, MaxSetupCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref writeOffset, Reserved1);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalParameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalDataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, MaxParameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, MaxDataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataOffset);
+            ByteWriter.WriteByte(SMBParameters, ref writeOffset, setupCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref writeOffset, (ushort)Function);
+            ByteWriter.WriteBytes(SMBParameters, ref writeOffset, Setup);
 
-            this.SMBData = new byte[padding1 + parameterCount + padding2 + dataCount];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, (int)(padding1 + parameterCount + padding2), TransData);
+            SMBData = new byte[padding1 + parameterCount + padding2 + dataCount];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, (int)(padding1 + parameterCount + padding2), TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactResponse.cs
@@ -48,17 +48,17 @@ namespace SMBLibrary.SMB1
         public NTTransactResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int readOffset = 0;
-            Reserved1 = ByteReader.ReadBytes(this.SMBParameters, ref readOffset, 3);
-            TotalParameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            TotalDataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            ParameterDisplacement = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            DataDisplacement = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            byte setupCount = ByteReader.ReadByte(this.SMBParameters, ref readOffset);
-            Setup = ByteReader.ReadBytes(this.SMBParameters, ref offset, setupCount * 2);
+            Reserved1 = ByteReader.ReadBytes(SMBParameters, ref readOffset, 3);
+            TotalParameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            TotalDataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            ParameterDisplacement = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            DataDisplacement = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            byte setupCount = ByteReader.ReadByte(SMBParameters, ref readOffset);
+            Setup = ByteReader.ReadBytes(SMBParameters, ref offset, setupCount * 2);
 
             TransParameters = ByteReader.ReadBytes(buffer, (int)parameterOffset, (int)parameterCount);
             TransData = ByteReader.ReadBytes(buffer, (int)dataOffset, (int)dataCount);
@@ -78,23 +78,23 @@ namespace SMBLibrary.SMB1
             int padding2 = (int)(4 - (dataOffset % 4)) % 4;
             dataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
+            SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
             int writeOffset = 0;
-            ByteWriter.WriteBytes(this.SMBParameters, ref writeOffset, Reserved1, 3);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalParameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalDataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, ParameterDisplacement);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, DataDisplacement);
-            ByteWriter.WriteByte(this.SMBParameters, ref writeOffset, setupCount);
-            ByteWriter.WriteBytes(this.SMBParameters, ref writeOffset, Setup);
+            ByteWriter.WriteBytes(SMBParameters, ref writeOffset, Reserved1, 3);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalParameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalDataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, ParameterDisplacement);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, DataDisplacement);
+            ByteWriter.WriteByte(SMBParameters, ref writeOffset, setupCount);
+            ByteWriter.WriteBytes(SMBParameters, ref writeOffset, Setup);
 
-            this.SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, (int)(padding1 + parameterCount + padding2), TransData);
+            SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, (int)(padding1 + parameterCount + padding2), TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactSecondaryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NTTransactSecondaryRequest.cs
@@ -47,16 +47,16 @@ namespace SMBLibrary.SMB1
         public NTTransactSecondaryRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int readOffset = 0;
-            Reserved1 = ByteReader.ReadBytes(this.SMBParameters, ref readOffset, 3);
-            TotalParameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            TotalDataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint parameterOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            ParameterDisplacement = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataCount = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            uint dataOffset = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            DataDisplacement = LittleEndianReader.ReadUInt32(this.SMBParameters, ref readOffset);
-            Reserved2 = ByteReader.ReadByte(this.SMBParameters, ref readOffset);
+            Reserved1 = ByteReader.ReadBytes(SMBParameters, ref readOffset, 3);
+            TotalParameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            TotalDataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint parameterOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            ParameterDisplacement = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataCount = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            uint dataOffset = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            DataDisplacement = LittleEndianReader.ReadUInt32(SMBParameters, ref readOffset);
+            Reserved2 = ByteReader.ReadByte(SMBParameters, ref readOffset);
 
             TransParameters = ByteReader.ReadBytes(buffer, (int)parameterOffset, (int)parameterCount);
             TransData = ByteReader.ReadBytes(buffer, (int)dataOffset, (int)dataCount);
@@ -75,22 +75,22 @@ namespace SMBLibrary.SMB1
             int padding2 = (int)(4 - (dataOffset % 4)) % 4;
             dataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[SMBParametersLength];
+            SMBParameters = new byte[SMBParametersLength];
             int writeOffset = 0;
-            ByteWriter.WriteBytes(this.SMBParameters, ref writeOffset, Reserved1, 3);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalParameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, TotalDataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, parameterOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, ParameterDisplacement);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataCount);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, dataOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref writeOffset, DataDisplacement);
-            ByteWriter.WriteByte(this.SMBParameters, ref writeOffset, Reserved2);
+            ByteWriter.WriteBytes(SMBParameters, ref writeOffset, Reserved1, 3);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalParameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, TotalDataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, parameterOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, ParameterDisplacement);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataCount);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, dataOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref writeOffset, DataDisplacement);
+            ByteWriter.WriteByte(SMBParameters, ref writeOffset, Reserved2);
 
-            this.SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, (int)(padding1 + parameterCount + padding2), TransData);
+            SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, (int)(padding1 + parameterCount + padding2), TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateRequest.cs
@@ -28,14 +28,14 @@ namespace SMBLibrary.SMB1
         public NegotiateRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int dataOffset = 0;
-            while (dataOffset < this.SMBData.Length)
+            while (dataOffset < SMBData.Length)
             {
-                byte bufferFormat = ByteReader.ReadByte(this.SMBData, ref dataOffset);
+                byte bufferFormat = ByteReader.ReadByte(SMBData, ref dataOffset);
                 if (bufferFormat != SupportedBufferFormat)
                 {
                     throw new InvalidDataException("Unsupported Buffer Format");
                 }
-                string dialect = ByteReader.ReadNullTerminatedAnsiString(this.SMBData, dataOffset);
+                string dialect = ByteReader.ReadNullTerminatedAnsiString(SMBData, dataOffset);
                 Dialects.Add(dialect);
                 dataOffset += dialect.Length + 1;
             }
@@ -44,19 +44,19 @@ namespace SMBLibrary.SMB1
         public override byte[] GetBytes(bool isUnicode)
         {
             int length = 0;
-            foreach (string dialect in this.Dialects)
+            foreach (string dialect in Dialects)
             {
                 length += 1 + dialect.Length + 1;
             }
 
-            this.SMBParameters = new byte[0];
-            this.SMBData = new byte[length];
+            SMBParameters = new byte[0];
+            SMBData = new byte[length];
             int offset = 0;
-            foreach (string dialect in this.Dialects)
+            foreach (string dialect in Dialects)
             {
-                ByteWriter.WriteByte(this.SMBData, offset, 0x02);
-                ByteWriter.WriteAnsiString(this.SMBData, offset + 1, dialect, dialect.Length);
-                ByteWriter.WriteByte(this.SMBData, offset + 1 + dialect.Length, 0x00);
+                ByteWriter.WriteByte(SMBData, offset, 0x02);
+                ByteWriter.WriteAnsiString(SMBData, offset + 1, dialect, dialect.Length);
+                ByteWriter.WriteByte(SMBData, offset + 1 + dialect.Length, 0x00);
                 offset += 1 + dialect.Length + 1;
             }
             return base.GetBytes(isUnicode);

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponse.cs
@@ -46,50 +46,50 @@ namespace SMBLibrary.SMB1
 
         public NegotiateResponse(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            DialectIndex = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            SecurityMode = (SecurityMode)ByteReader.ReadByte(this.SMBParameters, 2);
-            MaxMpxCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 3);
-            MaxNumberVcs = LittleEndianConverter.ToUInt16(this.SMBParameters, 5);
-            MaxBufferSize = LittleEndianConverter.ToUInt32(this.SMBParameters, 7);
-            MaxRawSize = LittleEndianConverter.ToUInt32(this.SMBParameters, 11);
-            SessionKey = LittleEndianConverter.ToUInt32(this.SMBParameters, 15);
-            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(this.SMBParameters, 19);
-            SystemTime = FileTimeHelper.ReadFileTime(this.SMBParameters, 23);
-            ServerTimeZone = LittleEndianConverter.ToInt16(this.SMBParameters, 31);
-            ChallengeLength = ByteReader.ReadByte(this.SMBParameters, 33);
+            DialectIndex = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            SecurityMode = (SecurityMode)ByteReader.ReadByte(SMBParameters, 2);
+            MaxMpxCount = LittleEndianConverter.ToUInt16(SMBParameters, 3);
+            MaxNumberVcs = LittleEndianConverter.ToUInt16(SMBParameters, 5);
+            MaxBufferSize = LittleEndianConverter.ToUInt32(SMBParameters, 7);
+            MaxRawSize = LittleEndianConverter.ToUInt32(SMBParameters, 11);
+            SessionKey = LittleEndianConverter.ToUInt32(SMBParameters, 15);
+            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(SMBParameters, 19);
+            SystemTime = FileTimeHelper.ReadFileTime(SMBParameters, 23);
+            ServerTimeZone = LittleEndianConverter.ToInt16(SMBParameters, 31);
+            ChallengeLength = ByteReader.ReadByte(SMBParameters, 33);
 
             int dataOffset = 0;
-            Challenge = ByteReader.ReadBytes(this.SMBData, ref dataOffset, ChallengeLength);
+            Challenge = ByteReader.ReadBytes(SMBData, ref dataOffset, ChallengeLength);
             // [MS-CIFS] <90> Padding is not added before DomainName
             // DomainName and ServerName are always in Unicode
-            DomainName = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, true);
-            ServerName = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, true);
+            DomainName = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, true);
+            ServerName = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, true);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            ChallengeLength = (byte)this.Challenge.Length;
+            ChallengeLength = (byte)Challenge.Length;
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, DialectIndex);
-            ByteWriter.WriteByte(this.SMBParameters, 2, (byte)SecurityMode);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 3, MaxMpxCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 5, MaxNumberVcs);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 7, MaxBufferSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 11, MaxRawSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 15, SessionKey);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 19, (uint)Capabilities);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, 23, SystemTime);
-            LittleEndianWriter.WriteInt16(this.SMBParameters, 31, ServerTimeZone);
-            ByteWriter.WriteByte(this.SMBParameters, 33, ChallengeLength);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, DialectIndex);
+            ByteWriter.WriteByte(SMBParameters, 2, (byte)SecurityMode);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 3, MaxMpxCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 5, MaxNumberVcs);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 7, MaxBufferSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 11, MaxRawSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 15, SessionKey);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 19, (uint)Capabilities);
+            FileTimeHelper.WriteFileTime(SMBParameters, 23, SystemTime);
+            LittleEndianWriter.WriteInt16(SMBParameters, 31, ServerTimeZone);
+            ByteWriter.WriteByte(SMBParameters, 33, ChallengeLength);
 
             // [MS-CIFS] <90> Padding is not added before DomainName
             // DomainName and ServerName are always in Unicode
-            this.SMBData = new byte[Challenge.Length + (DomainName.Length + 1) * 2 + (ServerName.Length + 1) * 2];
+            SMBData = new byte[Challenge.Length + (DomainName.Length + 1) * 2 + (ServerName.Length + 1) * 2];
             int offset = 0;
-            ByteWriter.WriteBytes(this.SMBData, ref offset, Challenge);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, true, DomainName);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, true, ServerName);
+            ByteWriter.WriteBytes(SMBData, ref offset, Challenge);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, true, DomainName);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, true, ServerName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponseExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponseExtended.cs
@@ -43,42 +43,42 @@ namespace SMBLibrary.SMB1
 
         public NegotiateResponseExtended(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            DialectIndex = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            SecurityMode = (SecurityMode)ByteReader.ReadByte(this.SMBParameters, 2);
-            MaxMpxCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 3);
-            MaxNumberVcs = LittleEndianConverter.ToUInt16(this.SMBParameters, 5);
-            MaxBufferSize = LittleEndianConverter.ToUInt32(this.SMBParameters, 7);
-            MaxRawSize = LittleEndianConverter.ToUInt32(this.SMBParameters, 11);
-            SessionKey = LittleEndianConverter.ToUInt32(this.SMBParameters, 15);
-            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(this.SMBParameters, 19);
-            SystemTime = FileTimeHelper.ReadFileTime(this.SMBParameters, 23);
-            ServerTimeZone = LittleEndianConverter.ToInt16(this.SMBParameters, 31);
-            ChallengeLength = ByteReader.ReadByte(this.SMBParameters, 33);
+            DialectIndex = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            SecurityMode = (SecurityMode)ByteReader.ReadByte(SMBParameters, 2);
+            MaxMpxCount = LittleEndianConverter.ToUInt16(SMBParameters, 3);
+            MaxNumberVcs = LittleEndianConverter.ToUInt16(SMBParameters, 5);
+            MaxBufferSize = LittleEndianConverter.ToUInt32(SMBParameters, 7);
+            MaxRawSize = LittleEndianConverter.ToUInt32(SMBParameters, 11);
+            SessionKey = LittleEndianConverter.ToUInt32(SMBParameters, 15);
+            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(SMBParameters, 19);
+            SystemTime = FileTimeHelper.ReadFileTime(SMBParameters, 23);
+            ServerTimeZone = LittleEndianConverter.ToInt16(SMBParameters, 31);
+            ChallengeLength = ByteReader.ReadByte(SMBParameters, 33);
 
-            ServerGuid = LittleEndianConverter.ToGuid(this.SMBData, 0);
-            SecurityBlob = ByteReader.ReadBytes(this.SMBData, 16, this.SMBData.Length - 16);
+            ServerGuid = LittleEndianConverter.ToGuid(SMBData, 0);
+            SecurityBlob = ByteReader.ReadBytes(SMBData, 16, SMBData.Length - 16);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
             ChallengeLength = 0;
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, DialectIndex);
-            ByteWriter.WriteByte(this.SMBParameters, 2, (byte)SecurityMode);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 3, MaxMpxCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 5, MaxNumberVcs);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 7, MaxBufferSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 11, MaxRawSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 15, SessionKey);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 19, (uint)Capabilities);
-            FileTimeHelper.WriteFileTime(this.SMBParameters, 23, SystemTime);
-            LittleEndianWriter.WriteInt16(this.SMBParameters, 31, ServerTimeZone);
-            ByteWriter.WriteByte(this.SMBParameters, 33, ChallengeLength);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, DialectIndex);
+            ByteWriter.WriteByte(SMBParameters, 2, (byte)SecurityMode);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 3, MaxMpxCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 5, MaxNumberVcs);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 7, MaxBufferSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 11, MaxRawSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 15, SessionKey);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 19, (uint)Capabilities);
+            FileTimeHelper.WriteFileTime(SMBParameters, 23, SystemTime);
+            LittleEndianWriter.WriteInt16(SMBParameters, 31, ServerTimeZone);
+            ByteWriter.WriteByte(SMBParameters, 33, ChallengeLength);
 
-            this.SMBData = new byte[16 + SecurityBlob.Length];
-            LittleEndianWriter.WriteGuid(this.SMBData, 0, ServerGuid);
-            ByteWriter.WriteBytes(this.SMBData, 16, SecurityBlob);
+            SMBData = new byte[16 + SecurityBlob.Length];
+            LittleEndianWriter.WriteGuid(SMBData, 0, ServerGuid);
+            ByteWriter.WriteBytes(SMBData, 16, SecurityBlob);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponseNotSupported.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/NegotiateResponseNotSupported.cs
@@ -29,10 +29,10 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, DialectsNotSupported);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, DialectsNotSupported);
 
-            this.SMBData = new byte[0];
+            SMBData = new byte[0];
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXRequest.cs
@@ -42,49 +42,49 @@ namespace SMBLibrary.SMB1
         public OpenAndXRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
             int parametersOffset = 4;
-            Flags = (OpenFlags)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            AccessMode = AccessModeOptions.Read(this.SMBParameters, ref parametersOffset);
-            SearchAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            FileAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            CreationTime = UTimeHelper.ReadNullableUTime(this.SMBParameters, ref parametersOffset);
-            OpenMode = OpenMode.Read(this.SMBParameters, ref parametersOffset);
-            AllocationSize = LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            Timeout = LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            Reserved = LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
+            Flags = (OpenFlags)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            AccessMode = AccessModeOptions.Read(SMBParameters, ref parametersOffset);
+            SearchAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            FileAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            CreationTime = UTimeHelper.ReadNullableUTime(SMBParameters, ref parametersOffset);
+            OpenMode = OpenMode.Read(SMBParameters, ref parametersOffset);
+            AllocationSize = LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            Timeout = LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            Reserved = LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
 
             int dataOffset = 0;
             if (isUnicode)
             {
                 dataOffset = 1; // 1 byte padding for 2 byte alignment
             }
-            FileName = SMB1Helper.ReadSMBString(this.SMBData, dataOffset, isUnicode);
+            FileName = SMB1Helper.ReadSMBString(SMBData, dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)Flags);
-            AccessMode.WriteBytes(this.SMBParameters, ref parametersOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)SearchAttrs);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)FileAttrs);
-            UTimeHelper.WriteUTime(this.SMBParameters, ref parametersOffset, CreationTime);
-            OpenMode.WriteBytes(this.SMBParameters, ref parametersOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, AllocationSize);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, Timeout);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, Reserved);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)Flags);
+            AccessMode.WriteBytes(SMBParameters, ref parametersOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)SearchAttrs);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)FileAttrs);
+            UTimeHelper.WriteUTime(SMBParameters, ref parametersOffset, CreationTime);
+            OpenMode.WriteBytes(SMBParameters, ref parametersOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, AllocationSize);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, Timeout);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, Reserved);
 
             int padding = 0;
             if (isUnicode)
             {
                 padding = 1;
-                this.SMBData = new byte[padding + FileName.Length * 2 + 2];
+                SMBData = new byte[padding + FileName.Length * 2 + 2];
             }
             else
             {
-                this.SMBData = new byte[FileName.Length + 1];
+                SMBData = new byte[FileName.Length + 1];
             }
-            SMB1Helper.WriteSMBString(this.SMBData, padding, isUnicode, FileName);
+            SMB1Helper.WriteSMBString(SMBData, padding, isUnicode, FileName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXResponse.cs
@@ -40,30 +40,30 @@ namespace SMBLibrary.SMB1
         public OpenAndXResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
             int parametersOffset = 4;
-            FID = LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            FileAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            LastWriteTime = UTimeHelper.ReadNullableUTime(this.SMBParameters, ref parametersOffset);
-            FileDataSize = LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            AccessRights = (AccessRights)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            NMPipeStatus = NamedPipeStatus.Read(this.SMBParameters, ref parametersOffset);
-            OpenResults = OpenResults.Read(this.SMBParameters, ref parametersOffset);
-            Reserved = ByteReader.ReadBytes(this.SMBParameters, ref parametersOffset, 6);
+            FID = LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            FileAttrs = (SMBFileAttributes)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            LastWriteTime = UTimeHelper.ReadNullableUTime(SMBParameters, ref parametersOffset);
+            FileDataSize = LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            AccessRights = (AccessRights)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            ResourceType = (ResourceType)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            NMPipeStatus = NamedPipeStatus.Read(SMBParameters, ref parametersOffset);
+            OpenResults = OpenResults.Read(SMBParameters, ref parametersOffset);
+            Reserved = ByteReader.ReadBytes(SMBParameters, ref parametersOffset, 6);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, FID);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)FileAttrs);
-            UTimeHelper.WriteUTime(this.SMBParameters, ref parametersOffset, LastWriteTime);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, FileDataSize);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)AccessRights);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)ResourceType);
-            NMPipeStatus.WriteBytes(this.SMBParameters, ref parametersOffset);
-            OpenResults.WriteBytes(this.SMBParameters, ref parametersOffset);
-            ByteWriter.WriteBytes(this.SMBParameters, ref parametersOffset, Reserved, 6);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, FID);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)FileAttrs);
+            UTimeHelper.WriteUTime(SMBParameters, ref parametersOffset, LastWriteTime);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, FileDataSize);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)AccessRights);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)ResourceType);
+            NMPipeStatus.WriteBytes(SMBParameters, ref parametersOffset);
+            OpenResults.WriteBytes(SMBParameters, ref parametersOffset);
+            ByteWriter.WriteBytes(SMBParameters, ref parametersOffset, Reserved, 6);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXResponseExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/OpenAndXResponseExtended.cs
@@ -46,20 +46,20 @@ namespace SMBLibrary.SMB1
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, FID);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)FileAttrs);
-            UTimeHelper.WriteUTime(this.SMBParameters, ref parametersOffset, LastWriteTime);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, FileDataSize);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)AccessRights);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)ResourceType);
-            NMPipeStatus.WriteBytes(this.SMBParameters, ref parametersOffset);
-            OpenResults.WriteBytes(this.SMBParameters, ref parametersOffset);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, ServerFID);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, Reserved);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)MaximalAccessRights);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)GuestMaximalAccessRights);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, FID);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)FileAttrs);
+            UTimeHelper.WriteUTime(SMBParameters, ref parametersOffset, LastWriteTime);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, FileDataSize);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)AccessRights);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)ResourceType);
+            NMPipeStatus.WriteBytes(SMBParameters, ref parametersOffset);
+            OpenResults.WriteBytes(SMBParameters, ref parametersOffset);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, ServerFID);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, Reserved);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)MaximalAccessRights);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)GuestMaximalAccessRights);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/QueryInformationRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/QueryInformationRequest.cs
@@ -33,12 +33,12 @@ namespace SMBLibrary.SMB1
 
         public QueryInformationRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            FileName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            FileName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -52,9 +52,9 @@ namespace SMBLibrary.SMB1
             {
                 length += FileName.Length + 1;
             }
-            this.SMBData = new byte[1 + length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            SMB1Helper.WriteSMBString(this.SMBData, 1, isUnicode, FileName);
+            SMBData = new byte[1 + length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            SMB1Helper.WriteSMBString(SMBData, 1, isUnicode, FileName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/QueryInformationResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/QueryInformationResponse.cs
@@ -33,19 +33,19 @@ namespace SMBLibrary.SMB1
 
         public QueryInformationResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FileAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            LastWriteTime = UTimeHelper.ReadNullableUTime(this.SMBParameters, 2);
-            FileSize = LittleEndianConverter.ToUInt32(this.SMBParameters, 6);
-            Reserved = ByteReader.ReadBytes(this.SMBParameters, 10, 10);
+            FileAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            LastWriteTime = UTimeHelper.ReadNullableUTime(SMBParameters, 2);
+            FileSize = LittleEndianConverter.ToUInt32(SMBParameters, 6);
+            Reserved = ByteReader.ReadBytes(SMBParameters, 10, 10);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParameterLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, (ushort)FileAttributes);
-            UTimeHelper.WriteUTime(this.SMBParameters, 2, LastWriteTime);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 6, FileSize);
-            ByteWriter.WriteBytes(this.SMBParameters, 10, Reserved, 10);
+            SMBParameters = new byte[ParameterLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, (ushort)FileAttributes);
+            UTimeHelper.WriteUTime(SMBParameters, 2, LastWriteTime);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 6, FileSize);
+            ByteWriter.WriteBytes(SMBParameters, 10, Reserved, 10);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadAndXRequest.cs
@@ -43,15 +43,15 @@ namespace SMBLibrary.SMB1
 
         public ReadAndXRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            Offset = LittleEndianConverter.ToUInt32(this.SMBParameters, 6);
-            MaxCountOfBytesToReturn = LittleEndianConverter.ToUInt16(this.SMBParameters, 10);
-            MinCountOfBytesToReturn = LittleEndianConverter.ToUInt16(this.SMBParameters, 12);
-            Timeout_or_MaxCountHigh = LittleEndianConverter.ToUInt32(this.SMBParameters, 14);
-            Remaining = LittleEndianConverter.ToUInt16(this.SMBParameters, 18);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            Offset = LittleEndianConverter.ToUInt32(SMBParameters, 6);
+            MaxCountOfBytesToReturn = LittleEndianConverter.ToUInt16(SMBParameters, 10);
+            MinCountOfBytesToReturn = LittleEndianConverter.ToUInt16(SMBParameters, 12);
+            Timeout_or_MaxCountHigh = LittleEndianConverter.ToUInt32(SMBParameters, 14);
+            Remaining = LittleEndianConverter.ToUInt16(SMBParameters, 18);
             if (SMBParameters.Length == ParametersFixedLength + 4)
             {
-                uint offsetHigh = LittleEndianConverter.ToUInt32(this.SMBParameters, 20);
+                uint offsetHigh = LittleEndianConverter.ToUInt32(SMBParameters, 20);
                 Offset |= ((ulong)offsetHigh << 32);
             }
         }
@@ -64,17 +64,17 @@ namespace SMBLibrary.SMB1
                 parametersLength += 4;
             }
 
-            this.SMBParameters = new byte[parametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, FID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 6, (uint)(Offset & 0xFFFFFFFF));
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, (ushort)(MaxCountOfBytesToReturn & 0xFFFF));
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, MinCountOfBytesToReturn);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 14, Timeout_or_MaxCountHigh);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 18, Remaining);
+            SMBParameters = new byte[parametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, FID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 6, (uint)(Offset & 0xFFFFFFFF));
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, (ushort)(MaxCountOfBytesToReturn & 0xFFFF));
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, MinCountOfBytesToReturn);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 14, Timeout_or_MaxCountHigh);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 18, Remaining);
             if (Offset > UInt32.MaxValue)
             {
                 uint offsetHigh = (uint)(Offset >> 32);
-                LittleEndianWriter.WriteUInt32(this.SMBParameters, 20, offsetHigh);
+                LittleEndianWriter.WriteUInt32(SMBParameters, 20, offsetHigh);
             }
 
             return base.GetBytes(isUnicode);

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadAndXResponse.cs
@@ -41,12 +41,12 @@ namespace SMBLibrary.SMB1
 
         public ReadAndXResponse(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            Available = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            DataCompactionMode = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            Reserved1 = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
-            uint DataLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 10);
-            ushort DataOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 12);
-            ushort dataLengthHigh = LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
+            Available = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            DataCompactionMode = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            Reserved1 = LittleEndianConverter.ToUInt16(SMBParameters, 8);
+            uint DataLength = LittleEndianConverter.ToUInt16(SMBParameters, 10);
+            ushort DataOffset = LittleEndianConverter.ToUInt16(SMBParameters, 12);
+            ushort dataLengthHigh = LittleEndianConverter.ToUInt16(SMBParameters, 14);
             Reserved2 = ByteReader.ReadBytes(buffer, 16, 8);
 
             DataLength |= (uint)(dataLengthHigh << 16);
@@ -65,27 +65,27 @@ namespace SMBLibrary.SMB1
             }
             ushort dataLengthHigh = (ushort)(DataLength >> 16);
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, Available);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, DataCompactionMode);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, Reserved1);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, (ushort)(DataLength & 0xFFFF));
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, DataOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, dataLengthHigh);
-            ByteWriter.WriteBytes(this.SMBParameters, 16, Reserved2);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, Available);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, DataCompactionMode);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, Reserved1);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, (ushort)(DataLength & 0xFFFF));
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, DataOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, dataLengthHigh);
+            ByteWriter.WriteBytes(SMBParameters, 16, Reserved2);
 
             int smbDataLength = Data.Length;
             if (isUnicode)
             {
                 smbDataLength++;
             }
-            this.SMBData = new byte[smbDataLength];
+            SMBData = new byte[smbDataLength];
             int offset = 0;
             if (isUnicode)
             {
                 offset++;
             }
-            ByteWriter.WriteBytes(this.SMBData, offset, this.Data);
+            ByteWriter.WriteBytes(SMBData, offset, Data);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadRequest.cs
@@ -29,19 +29,19 @@ namespace SMBLibrary.SMB1
 
         public ReadRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            CountOfBytesToRead = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
-            ReadOffsetInBytes = LittleEndianConverter.ToUInt32(this.SMBParameters, 4);
-            CountOfBytesToRead = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            CountOfBytesToRead = LittleEndianConverter.ToUInt16(SMBParameters, 2);
+            ReadOffsetInBytes = LittleEndianConverter.ToUInt32(SMBParameters, 4);
+            CountOfBytesToRead = LittleEndianConverter.ToUInt16(SMBParameters, 8);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, FID);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, CountOfBytesToRead);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 4, ReadOffsetInBytes);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, CountOfBytesToRead);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, FID);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, CountOfBytesToRead);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 4, ReadOffsetInBytes);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, CountOfBytesToRead);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/ReadResponse.cs
@@ -36,28 +36,28 @@ namespace SMBLibrary.SMB1
 
         public ReadResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            CountOfBytesReturned = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            Reserved = ByteReader.ReadBytes(this.SMBParameters, 2, 8);
+            CountOfBytesReturned = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            Reserved = ByteReader.ReadBytes(SMBParameters, 2, 8);
 
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            ushort CountOfBytesRead = LittleEndianConverter.ToUInt16(this.SMBData, 1);
-            Bytes = ByteReader.ReadBytes(this.SMBData, 3, CountOfBytesRead);
+            ushort CountOfBytesRead = LittleEndianConverter.ToUInt16(SMBData, 1);
+            Bytes = ByteReader.ReadBytes(SMBData, 3, CountOfBytesRead);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, CountOfBytesReturned);
-            ByteWriter.WriteBytes(this.SMBParameters, 2, Reserved, 8);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, CountOfBytesReturned);
+            ByteWriter.WriteBytes(SMBParameters, 2, Reserved, 8);
 
-            this.SMBData = new byte[3 + Bytes.Length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            LittleEndianWriter.WriteUInt16(this.SMBData, 1, (ushort)Bytes.Length);
-            ByteWriter.WriteBytes(this.SMBData, 3, Bytes);
+            SMBData = new byte[3 + Bytes.Length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            LittleEndianWriter.WriteUInt16(SMBData, 1, (ushort)Bytes.Length);
+            ByteWriter.WriteBytes(SMBData, 3, Bytes);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/RenameRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/RenameRequest.cs
@@ -36,16 +36,16 @@ namespace SMBLibrary.SMB1
 
         public RenameRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            SearchAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            SearchAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(SMBParameters, 0);
 
             int dataOffset = 0;
-            BufferFormat1 = ByteReader.ReadByte(this.SMBData, ref dataOffset);
+            BufferFormat1 = ByteReader.ReadByte(SMBData, ref dataOffset);
             if (BufferFormat1 != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            OldFileName = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            BufferFormat2 = ByteReader.ReadByte(this.SMBData, ref dataOffset);
+            OldFileName = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            BufferFormat2 = ByteReader.ReadByte(SMBData, ref dataOffset);
             if (BufferFormat2 != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
@@ -54,32 +54,32 @@ namespace SMBLibrary.SMB1
             {
                 dataOffset++;
             }
-            NewFileName = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            NewFileName = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, (ushort)SearchAttributes);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, (ushort)SearchAttributes);
 
             if (isUnicode)
             {
                 int padding = 1;
-                this.SMBData = new byte[2 + OldFileName.Length * 2 + NewFileName.Length * 2 + 4 + padding];
+                SMBData = new byte[2 + OldFileName.Length * 2 + NewFileName.Length * 2 + 4 + padding];
             }
             else
             {
-                this.SMBData = new byte[2 + OldFileName.Length + NewFileName.Length + 2];
+                SMBData = new byte[2 + OldFileName.Length + NewFileName.Length + 2];
             }
             int dataOffset = 0;
-            ByteWriter.WriteByte(this.SMBData, ref dataOffset, BufferFormat1);
-            SMB1Helper.WriteSMBString(this.SMBData, ref dataOffset, isUnicode, OldFileName);
-            ByteWriter.WriteByte(this.SMBData, ref dataOffset, BufferFormat2);
+            ByteWriter.WriteByte(SMBData, ref dataOffset, BufferFormat1);
+            SMB1Helper.WriteSMBString(SMBData, ref dataOffset, isUnicode, OldFileName);
+            ByteWriter.WriteByte(SMBData, ref dataOffset, BufferFormat2);
             if (isUnicode)
             {
                 dataOffset++; // padding
             }
-            SMB1Helper.WriteSMBString(this.SMBData, ref dataOffset, isUnicode, NewFileName);
+            SMB1Helper.WriteSMBString(SMBData, ref dataOffset, isUnicode, NewFileName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SMB1Command.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SMB1Command.cs
@@ -398,7 +398,7 @@ namespace SMBLibrary.SMB1
                     }
                 case CommandName.SMB_COM_TRANSACTION2:
                     {
-                        if (wordCount * 2 == Transaction2InterimResponse.ParametersLength)
+                        if (wordCount * 2 == TransactionInterimResponse.ParametersLength)
                         {
                             return new Transaction2InterimResponse(buffer, offset);
                         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SMBAndXCommand.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SMBAndXCommand.cs
@@ -21,16 +21,16 @@ namespace SMBLibrary.SMB1
 
         public SMBAndXCommand(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            AndXCommand = (CommandName)ByteReader.ReadByte(this.SMBParameters, 0);
-            AndXReserved = ByteReader.ReadByte(this.SMBParameters, 1);
-            AndXOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
+            AndXCommand = (CommandName)ByteReader.ReadByte(SMBParameters, 0);
+            AndXReserved = ByteReader.ReadByte(SMBParameters, 1);
+            AndXOffset = LittleEndianConverter.ToUInt16(SMBParameters, 2);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            ByteWriter.WriteByte(this.SMBParameters, 0, (byte)AndXCommand);
-            ByteWriter.WriteByte(this.SMBParameters, 1, AndXReserved);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, AndXOffset);
+            ByteWriter.WriteByte(SMBParameters, 0, (byte)AndXCommand);
+            ByteWriter.WriteByte(SMBParameters, 1, AndXReserved);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, AndXOffset);
             return base.GetBytes(isUnicode);
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXRequest.cs
@@ -50,17 +50,17 @@ namespace SMBLibrary.SMB1
 
         public SessionSetupAndXRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            MaxBufferSize = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            MaxMpxCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            VcNumber = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
-            SessionKey = LittleEndianConverter.ToUInt32(this.SMBParameters, 10);
-            OEMPasswordLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
-            UnicodePasswordLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 16);
-            Reserved = LittleEndianConverter.ToUInt32(this.SMBParameters, 18);
-            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(this.SMBParameters, 22);
+            MaxBufferSize = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            MaxMpxCount = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            VcNumber = LittleEndianConverter.ToUInt16(SMBParameters, 8);
+            SessionKey = LittleEndianConverter.ToUInt32(SMBParameters, 10);
+            OEMPasswordLength = LittleEndianConverter.ToUInt16(SMBParameters, 14);
+            UnicodePasswordLength = LittleEndianConverter.ToUInt16(SMBParameters, 16);
+            Reserved = LittleEndianConverter.ToUInt32(SMBParameters, 18);
+            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(SMBParameters, 22);
 
-            OEMPassword = ByteReader.ReadBytes(this.SMBData, 0, OEMPasswordLength);
-            UnicodePassword = ByteReader.ReadBytes(this.SMBData, OEMPasswordLength, UnicodePasswordLength);
+            OEMPassword = ByteReader.ReadBytes(SMBData, 0, OEMPasswordLength);
+            UnicodePassword = ByteReader.ReadBytes(SMBData, OEMPasswordLength, UnicodePasswordLength);
 
             int dataOffset = OEMPasswordLength + UnicodePasswordLength;
             if (isUnicode)
@@ -70,10 +70,10 @@ namespace SMBLibrary.SMB1
                 int padding = (1 + OEMPasswordLength + UnicodePasswordLength) % 2;
                 dataOffset += padding;
             }
-            AccountName = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            PrimaryDomain = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            NativeOS = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            NativeLanMan = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            AccountName = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            PrimaryDomain = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            NativeOS = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            NativeLanMan = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -83,15 +83,15 @@ namespace SMBLibrary.SMB1
             OEMPasswordLength = (ushort)OEMPassword.Length;
             UnicodePasswordLength = (ushort)UnicodePassword.Length;
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, MaxBufferSize);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, MaxMpxCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, VcNumber);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 10, SessionKey);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, OEMPasswordLength);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 16, UnicodePasswordLength);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 18, Reserved);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 22, (uint)Capabilities);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, MaxBufferSize);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, MaxMpxCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, VcNumber);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 10, SessionKey);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, OEMPasswordLength);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 16, UnicodePasswordLength);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 18, Reserved);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 22, (uint)Capabilities);
 
             int padding = 0;
             if (isUnicode)
@@ -99,20 +99,20 @@ namespace SMBLibrary.SMB1
                 // A Unicode string MUST be aligned to a 16-bit boundary with respect to the beginning of the SMB Header.
                 // Note: SMBData starts at an odd offset.
                 padding = (1 + OEMPasswordLength + UnicodePasswordLength) % 2;
-                this.SMBData = new byte[OEMPassword.Length + UnicodePassword.Length + padding + (AccountName.Length + 1) * 2 + (PrimaryDomain.Length + 1) * 2 + (NativeOS.Length + 1) * 2 + (NativeLanMan.Length + 1) * 2];
+                SMBData = new byte[OEMPassword.Length + UnicodePassword.Length + padding + (AccountName.Length + 1) * 2 + (PrimaryDomain.Length + 1) * 2 + (NativeOS.Length + 1) * 2 + (NativeLanMan.Length + 1) * 2];
             }
             else
             {
-                this.SMBData = new byte[OEMPassword.Length + UnicodePassword.Length + AccountName.Length + 1 + PrimaryDomain.Length + 1 + NativeOS.Length + 1 + NativeLanMan.Length + 1];
+                SMBData = new byte[OEMPassword.Length + UnicodePassword.Length + AccountName.Length + 1 + PrimaryDomain.Length + 1 + NativeOS.Length + 1 + NativeLanMan.Length + 1];
             }
             int offset = 0;
-            ByteWriter.WriteBytes(this.SMBData, ref offset, OEMPassword);
-            ByteWriter.WriteBytes(this.SMBData, ref offset, UnicodePassword);
+            ByteWriter.WriteBytes(SMBData, ref offset, OEMPassword);
+            ByteWriter.WriteBytes(SMBData, ref offset, UnicodePassword);
             offset += padding;
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, AccountName);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, PrimaryDomain);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeOS);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeLanMan);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, AccountName);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, PrimaryDomain);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeOS);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeLanMan);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXRequestExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXRequestExtended.cs
@@ -41,15 +41,15 @@ namespace SMBLibrary.SMB1
 
         public SessionSetupAndXRequestExtended(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            MaxBufferSize = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            MaxMpxCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            VcNumber = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
-            SessionKey = LittleEndianConverter.ToUInt32(this.SMBParameters, 10);
-            SecurityBlobLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
-            Reserved = LittleEndianConverter.ToUInt32(this.SMBParameters, 16);
-            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(this.SMBParameters, 20);
+            MaxBufferSize = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            MaxMpxCount = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            VcNumber = LittleEndianConverter.ToUInt16(SMBParameters, 8);
+            SessionKey = LittleEndianConverter.ToUInt32(SMBParameters, 10);
+            SecurityBlobLength = LittleEndianConverter.ToUInt16(SMBParameters, 14);
+            Reserved = LittleEndianConverter.ToUInt32(SMBParameters, 16);
+            Capabilities = (Capabilities)LittleEndianConverter.ToUInt32(SMBParameters, 20);
 
-            SecurityBlob = ByteReader.ReadBytes(this.SMBData, 0, SecurityBlobLength);
+            SecurityBlob = ByteReader.ReadBytes(SMBData, 0, SecurityBlobLength);
 
             int dataOffset = SecurityBlob.Length;
             if (isUnicode)
@@ -59,8 +59,8 @@ namespace SMBLibrary.SMB1
                 int padding = (1 + SecurityBlobLength) % 2;
                 dataOffset += padding;
             }
-            NativeOS = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            NativeLanMan = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            NativeOS = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            NativeLanMan = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -68,14 +68,14 @@ namespace SMBLibrary.SMB1
             Capabilities |= Capabilities.ExtendedSecurity;
             SecurityBlobLength = (ushort)SecurityBlob.Length;
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, MaxBufferSize);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, MaxMpxCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, VcNumber);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 10, SessionKey);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, SecurityBlobLength);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 16, Reserved);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 20, (uint)Capabilities);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, MaxBufferSize);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, MaxMpxCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, VcNumber);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 10, SessionKey);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, SecurityBlobLength);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 16, Reserved);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 20, (uint)Capabilities);
 
             int padding = 0;
             if (isUnicode)
@@ -83,17 +83,17 @@ namespace SMBLibrary.SMB1
                 // A Unicode string MUST be aligned to a 16-bit boundary with respect to the beginning of the SMB Header.
                 // Note: SMBData starts at an odd offset.
                 padding = (1 + SecurityBlobLength) % 2;
-                this.SMBData = new byte[SecurityBlob.Length + padding + (NativeOS.Length + 1) * 2 + (NativeLanMan.Length + 1) * 2];
+                SMBData = new byte[SecurityBlob.Length + padding + (NativeOS.Length + 1) * 2 + (NativeLanMan.Length + 1) * 2];
             }
             else
             {
-                this.SMBData = new byte[SecurityBlob.Length + NativeOS.Length + 1 + NativeLanMan.Length + 1];
+                SMBData = new byte[SecurityBlob.Length + NativeOS.Length + 1 + NativeLanMan.Length + 1];
             }
             int offset = 0;
-            ByteWriter.WriteBytes(this.SMBData, ref offset, SecurityBlob);
+            ByteWriter.WriteBytes(SMBData, ref offset, SecurityBlob);
             offset += padding;
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeOS);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeLanMan);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeOS);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeLanMan);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXResponse.cs
@@ -38,7 +38,7 @@ namespace SMBLibrary.SMB1
 
         public SessionSetupAndXResponse(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            Action = (SessionSetupAction)LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
+            Action = (SessionSetupAction)LittleEndianConverter.ToUInt16(SMBParameters, 4);
 
             int dataOffset = 0;
             if (isUnicode)
@@ -47,20 +47,20 @@ namespace SMBLibrary.SMB1
                 // Note: SMBData starts at an odd offset.
                 dataOffset++;
             }
-            NativeOS = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            NativeLanMan = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            if ((this.SMBData.Length - dataOffset) % 2 == 1)
+            NativeOS = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            NativeLanMan = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            if ((SMBData.Length - dataOffset) % 2 == 1)
             {
                 // Workaround for a single terminating null byte
-                this.SMBData = ByteUtils.Concatenate(this.SMBData, new byte[1]);
+                SMBData = ByteUtils.Concatenate(SMBData, new byte[1]);
             }
-            PrimaryDomain = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            PrimaryDomain = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, (ushort)Action);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, (ushort)Action);
 
             int offset = 0;
             if (isUnicode)
@@ -68,16 +68,16 @@ namespace SMBLibrary.SMB1
                 // A Unicode string MUST be aligned to a 16-bit boundary with respect to the beginning of the SMB Header.
                 // Note: SMBData starts at an odd offset.
                 int padding = 1;
-                this.SMBData = new byte[padding + NativeOS.Length * 2 + NativeLanMan.Length * 2 + PrimaryDomain.Length * 2 + 6];
+                SMBData = new byte[padding + NativeOS.Length * 2 + NativeLanMan.Length * 2 + PrimaryDomain.Length * 2 + 6];
                 offset = padding;
             }
             else
             {
-                this.SMBData = new byte[NativeOS.Length + NativeLanMan.Length + PrimaryDomain.Length + 3];
+                SMBData = new byte[NativeOS.Length + NativeLanMan.Length + PrimaryDomain.Length + 3];
             }
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeOS);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeLanMan);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, PrimaryDomain);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeOS);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeLanMan);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, PrimaryDomain);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXResponseExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SessionSetupAndXResponseExtended.cs
@@ -40,10 +40,10 @@ namespace SMBLibrary.SMB1
 
         public SessionSetupAndXResponseExtended(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            Action = (SessionSetupAction)LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            SecurityBlobLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
+            Action = (SessionSetupAction)LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            SecurityBlobLength = LittleEndianConverter.ToUInt16(SMBParameters, 6);
 
-            SecurityBlob = ByteReader.ReadBytes(this.SMBData, 0, SecurityBlobLength);
+            SecurityBlob = ByteReader.ReadBytes(SMBData, 0, SecurityBlobLength);
 
             int dataOffset = SecurityBlob.Length;
             if (isUnicode)
@@ -53,22 +53,22 @@ namespace SMBLibrary.SMB1
                 int padding = (1 + SecurityBlobLength) % 2;
                 dataOffset += padding;
             }
-            NativeOS = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
-            if ((this.SMBData.Length - dataOffset) % 2 == 1)
+            NativeOS = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
+            if ((SMBData.Length - dataOffset) % 2 == 1)
             {
                 // Workaround for a single terminating null byte
-                this.SMBData = ByteUtils.Concatenate(this.SMBData, new byte[1]);
+                SMBData = ByteUtils.Concatenate(SMBData, new byte[1]);
             }
-            NativeLanMan = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            NativeLanMan = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
             ushort securityBlobLength = (ushort)SecurityBlob.Length;
 
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, (ushort)Action);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, securityBlobLength);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, (ushort)Action);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, securityBlobLength);
 
             int padding = 0;
             if (isUnicode)
@@ -76,17 +76,17 @@ namespace SMBLibrary.SMB1
                 // A Unicode string MUST be aligned to a 16-bit boundary with respect to the beginning of the SMB Header.
                 // Note: SMBData starts at an odd offset.
                 padding = (1 + securityBlobLength) % 2;
-                this.SMBData = new byte[SecurityBlob.Length + padding + NativeOS.Length * 2 + NativeLanMan.Length * 2 + 4];
+                SMBData = new byte[SecurityBlob.Length + padding + NativeOS.Length * 2 + NativeLanMan.Length * 2 + 4];
             }
             else
             {
-                this.SMBData = new byte[SecurityBlob.Length + NativeOS.Length + NativeLanMan.Length + 2];
+                SMBData = new byte[SecurityBlob.Length + NativeOS.Length + NativeLanMan.Length + 2];
             }
             int offset = 0;
-            ByteWriter.WriteBytes(this.SMBData, ref offset, SecurityBlob);
+            ByteWriter.WriteBytes(SMBData, ref offset, SecurityBlob);
             offset += padding;
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeOS);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeLanMan);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeOS);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeLanMan);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SetInformation2Request.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SetInformation2Request.cs
@@ -30,19 +30,19 @@ namespace SMBLibrary.SMB1
 
         public SetInformation2Request(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            CreationDateTime = SMB1Helper.ReadNullableSMBDateTime(this.SMBParameters, 2);
-            LastAccessDateTime = SMB1Helper.ReadNullableSMBDateTime(this.SMBParameters, 6);
-            LastWriteDateTime = SMB1Helper.ReadNullableSMBDateTime(this.SMBParameters, 10);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            CreationDateTime = SMB1Helper.ReadNullableSMBDateTime(SMBParameters, 2);
+            LastAccessDateTime = SMB1Helper.ReadNullableSMBDateTime(SMBParameters, 6);
+            LastWriteDateTime = SMB1Helper.ReadNullableSMBDateTime(SMBParameters, 10);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, FID);
-            SMB1Helper.WriteSMBDateTime(this.SMBParameters, 2, CreationDateTime);
-            SMB1Helper.WriteSMBDateTime(this.SMBParameters, 6, LastAccessDateTime);
-            SMB1Helper.WriteSMBDateTime(this.SMBParameters, 10, LastWriteDateTime);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, FID);
+            SMB1Helper.WriteSMBDateTime(SMBParameters, 2, CreationDateTime);
+            SMB1Helper.WriteSMBDateTime(SMBParameters, 6, LastAccessDateTime);
+            SMB1Helper.WriteSMBDateTime(SMBParameters, 10, LastWriteDateTime);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SetInformationRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/SetInformationRequest.cs
@@ -38,24 +38,24 @@ namespace SMBLibrary.SMB1
 
         public SetInformationRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            FileAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            LastWriteTime = UTimeHelper.ReadNullableUTime(this.SMBParameters, 2);
-            Reserved = ByteReader.ReadBytes(this.SMBParameters, 6, 10);
+            FileAttributes = (SMBFileAttributes)LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            LastWriteTime = UTimeHelper.ReadNullableUTime(SMBParameters, 2);
+            Reserved = ByteReader.ReadBytes(SMBParameters, 6, 10);
 
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            FileName = SMB1Helper.ReadSMBString(this.SMBData, 1, isUnicode);
+            FileName = SMB1Helper.ReadSMBString(SMBData, 1, isUnicode);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, (ushort)FileAttributes);
-            UTimeHelper.WriteUTime(this.SMBParameters, 2, LastWriteTime);
-            ByteWriter.WriteBytes(this.SMBParameters, 6, Reserved, 10);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, (ushort)FileAttributes);
+            UTimeHelper.WriteUTime(SMBParameters, 2, LastWriteTime);
+            ByteWriter.WriteBytes(SMBParameters, 6, Reserved, 10);
 
             int length = 1;
             if (isUnicode)
@@ -66,9 +66,9 @@ namespace SMBLibrary.SMB1
             {
                 length += FileName.Length + 1;
             }
-            this.SMBData = new byte[length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            SMB1Helper.WriteSMBString(this.SMBData, 1, isUnicode, FileName);
+            SMBData = new byte[length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            SMB1Helper.WriteSMBString(SMBData, 1, isUnicode, FileName);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/Transaction2SecondaryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/Transaction2SecondaryRequest.cs
@@ -25,15 +25,15 @@ namespace SMBLibrary.SMB1
 
         public Transaction2SecondaryRequest(byte[] buffer, int offset) : base(buffer, offset)
         {
-            TotalParameterCount = LittleEndianConverter.ToUInt16(this.SMBData, 0);
-            TotalDataCount = LittleEndianConverter.ToUInt16(this.SMBData, 2);
-            ParameterCount = LittleEndianConverter.ToUInt16(this.SMBData, 4);
-            ParameterOffset = LittleEndianConverter.ToUInt16(this.SMBData, 6);
-            ParameterDisplacement = LittleEndianConverter.ToUInt16(this.SMBData, 8);
-            DataCount = LittleEndianConverter.ToUInt16(this.SMBData, 10);
-            DataOffset = LittleEndianConverter.ToUInt16(this.SMBData, 12);
-            DataDisplacement = LittleEndianConverter.ToUInt16(this.SMBData, 14);
-            FID = LittleEndianConverter.ToUInt16(this.SMBData, 16);
+            TotalParameterCount = LittleEndianConverter.ToUInt16(SMBData, 0);
+            TotalDataCount = LittleEndianConverter.ToUInt16(SMBData, 2);
+            ParameterCount = LittleEndianConverter.ToUInt16(SMBData, 4);
+            ParameterOffset = LittleEndianConverter.ToUInt16(SMBData, 6);
+            ParameterDisplacement = LittleEndianConverter.ToUInt16(SMBData, 8);
+            DataCount = LittleEndianConverter.ToUInt16(SMBData, 10);
+            DataOffset = LittleEndianConverter.ToUInt16(SMBData, 12);
+            DataDisplacement = LittleEndianConverter.ToUInt16(SMBData, 14);
+            FID = LittleEndianConverter.ToUInt16(SMBData, 16);
 
             TransParameters = ByteReader.ReadBytes(buffer, ParameterOffset, ParameterCount);
             TransData = ByteReader.ReadBytes(buffer, DataOffset, DataCount);
@@ -51,20 +51,20 @@ namespace SMBLibrary.SMB1
             int padding2 = (4 - (DataOffset % 4)) % 4;
             DataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[SMBParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, TotalParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, TotalDataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, ParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, ParameterOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, ParameterDisplacement);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, DataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, DataOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, DataDisplacement);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 16, FID);
+            SMBParameters = new byte[SMBParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, TotalParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, TotalDataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, ParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, ParameterOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, ParameterDisplacement);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, DataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, DataOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, DataDisplacement);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 16, FID);
 
-            this.SMBData = new byte[ParameterCount + DataCount + padding1 + padding2];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, padding1 + ParameterCount + padding2, TransData);
+            SMBData = new byte[ParameterCount + DataCount + padding1 + padding2];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, padding1 + ParameterCount + padding2, TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionRequest.cs
@@ -54,24 +54,24 @@ namespace SMBLibrary.SMB1
 
         public TransactionRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            TotalParameterCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            TotalDataCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
-            MaxParameterCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            MaxDataCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            MaxSetupCount = ByteReader.ReadByte(this.SMBParameters, 8);
-            Reserved1 = ByteReader.ReadByte(this.SMBParameters, 9);
-            Flags = (TransactionFlags)LittleEndianConverter.ToUInt16(this.SMBParameters, 10);
-            Timeout = LittleEndianConverter.ToUInt32(this.SMBParameters, 12);
-            Reserved2 = LittleEndianConverter.ToUInt16(this.SMBParameters, 16);
-            ushort transParameterCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 18);
-            ushort transParameterOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 20);
-            ushort transDataCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 22);
-            ushort transDataOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 24);
-            byte setupCount = ByteReader.ReadByte(this.SMBParameters, 26);
-            Reserved3 = ByteReader.ReadByte(this.SMBParameters, 27);
-            Setup = ByteReader.ReadBytes(this.SMBParameters, 28, setupCount * 2);
+            TotalParameterCount = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            TotalDataCount = LittleEndianConverter.ToUInt16(SMBParameters, 2);
+            MaxParameterCount = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            MaxDataCount = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            MaxSetupCount = ByteReader.ReadByte(SMBParameters, 8);
+            Reserved1 = ByteReader.ReadByte(SMBParameters, 9);
+            Flags = (TransactionFlags)LittleEndianConverter.ToUInt16(SMBParameters, 10);
+            Timeout = LittleEndianConverter.ToUInt32(SMBParameters, 12);
+            Reserved2 = LittleEndianConverter.ToUInt16(SMBParameters, 16);
+            ushort transParameterCount = LittleEndianConverter.ToUInt16(SMBParameters, 18);
+            ushort transParameterOffset = LittleEndianConverter.ToUInt16(SMBParameters, 20);
+            ushort transDataCount = LittleEndianConverter.ToUInt16(SMBParameters, 22);
+            ushort transDataOffset = LittleEndianConverter.ToUInt16(SMBParameters, 24);
+            byte setupCount = ByteReader.ReadByte(SMBParameters, 26);
+            Reserved3 = ByteReader.ReadByte(SMBParameters, 27);
+            Setup = ByteReader.ReadBytes(SMBParameters, 28, setupCount * 2);
 
-            if (this.SMBData.Length > 0) // Workaround, Some SAMBA clients will set ByteCount to 0 (Popcorn Hour A-400)
+            if (SMBData.Length > 0) // Workaround, Some SAMBA clients will set ByteCount to 0 (Popcorn Hour A-400)
             {
                 int dataOffset = 0;
                 if (this is Transaction2Request)
@@ -87,7 +87,7 @@ namespace SMBLibrary.SMB1
                         int namePadding = 1;
                         dataOffset += namePadding;
                     }
-                    Name = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+                    Name = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
                 }
             }
             TransParameters = ByteReader.ReadBytes(buffer, transParameterOffset, transParameterCount);
@@ -133,26 +133,26 @@ namespace SMBLibrary.SMB1
             int padding2 = (4 - (transDataOffset % 4)) % 4;
             transDataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, TotalParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, TotalDataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, MaxParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, MaxDataCount);
-            ByteWriter.WriteByte(this.SMBParameters, 8, MaxSetupCount);
-            ByteWriter.WriteByte(this.SMBParameters, 9, Reserved1);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, (ushort)Flags);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 12, Timeout);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 16, Reserved2);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 18, transParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 20, transParameterOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 22, transDataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 24, transDataOffset);
-            ByteWriter.WriteByte(this.SMBParameters, 26, setupCount);
-            ByteWriter.WriteByte(this.SMBParameters, 27, Reserved3);
-            ByteWriter.WriteBytes(this.SMBParameters, 28, Setup);
+            SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, TotalParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, TotalDataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, MaxParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, MaxDataCount);
+            ByteWriter.WriteByte(SMBParameters, 8, MaxSetupCount);
+            ByteWriter.WriteByte(SMBParameters, 9, Reserved1);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, (ushort)Flags);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 12, Timeout);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 16, Reserved2);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 18, transParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 20, transParameterOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 22, transDataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 24, transDataOffset);
+            ByteWriter.WriteByte(SMBParameters, 26, setupCount);
+            ByteWriter.WriteByte(SMBParameters, 27, Reserved3);
+            ByteWriter.WriteBytes(SMBParameters, 28, Setup);
 
             int offset;
-            this.SMBData = new byte[namePadding + nameLength + padding1 + transParameterCount + padding2 + transDataCount];
+            SMBData = new byte[namePadding + nameLength + padding1 + transParameterCount + padding2 + transDataCount];
             offset = namePadding;
             if (this is Transaction2Request)
             {
@@ -160,10 +160,10 @@ namespace SMBLibrary.SMB1
             }
             else
             {
-                SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, Name);
+                SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, Name);
             }
-            ByteWriter.WriteBytes(this.SMBData, offset + padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, offset + padding1 + transParameterCount + padding2, TransData);
+            ByteWriter.WriteBytes(SMBData, offset + padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, offset + padding1 + transParameterCount + padding2, TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionResponse.cs
@@ -52,18 +52,18 @@ namespace SMBLibrary.SMB1
 
         public TransactionResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            TotalParameterCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            TotalDataCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
-            Reserved1 = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            ushort parameterCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            ushort parameterOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
-            ParameterDisplacement = LittleEndianConverter.ToUInt16(this.SMBParameters, 10);
-            ushort dataCount = LittleEndianConverter.ToUInt16(this.SMBParameters, 12);
-            ushort dataOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
-            DataDisplacement = LittleEndianConverter.ToUInt16(this.SMBParameters, 16);
-            byte setupCount = ByteReader.ReadByte(this.SMBParameters, 18);
-            Reserved2 = ByteReader.ReadByte(this.SMBParameters, 19);
-            Setup = ByteReader.ReadBytes(this.SMBParameters, 20, setupCount * 2);
+            TotalParameterCount = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            TotalDataCount = LittleEndianConverter.ToUInt16(SMBParameters, 2);
+            Reserved1 = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            ushort parameterCount = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            ushort parameterOffset = LittleEndianConverter.ToUInt16(SMBParameters, 8);
+            ParameterDisplacement = LittleEndianConverter.ToUInt16(SMBParameters, 10);
+            ushort dataCount = LittleEndianConverter.ToUInt16(SMBParameters, 12);
+            ushort dataOffset = LittleEndianConverter.ToUInt16(SMBParameters, 14);
+            DataDisplacement = LittleEndianConverter.ToUInt16(SMBParameters, 16);
+            byte setupCount = ByteReader.ReadByte(SMBParameters, 18);
+            Reserved2 = ByteReader.ReadByte(SMBParameters, 19);
+            Setup = ByteReader.ReadBytes(SMBParameters, 20, setupCount * 2);
 
             TransParameters = ByteReader.ReadBytes(buffer, parameterOffset, parameterCount);
             TransData = ByteReader.ReadBytes(buffer, dataOffset, dataCount);
@@ -87,23 +87,23 @@ namespace SMBLibrary.SMB1
             int padding2 = (4 - (dataOffset % 4)) % 4;
             dataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, TotalParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, TotalDataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, Reserved1);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, parameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, parameterOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, ParameterDisplacement);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, dataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, dataOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 16, DataDisplacement);
-            ByteWriter.WriteByte(this.SMBParameters, 18, setupCount);
-            ByteWriter.WriteByte(this.SMBParameters, 19, Reserved2);
-            ByteWriter.WriteBytes(this.SMBParameters, 20, Setup);
+            SMBParameters = new byte[FixedSMBParametersLength + Setup.Length];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, TotalParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, TotalDataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, Reserved1);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, parameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, parameterOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, ParameterDisplacement);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, dataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, dataOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 16, DataDisplacement);
+            ByteWriter.WriteByte(SMBParameters, 18, setupCount);
+            ByteWriter.WriteByte(SMBParameters, 19, Reserved2);
+            ByteWriter.WriteBytes(SMBParameters, 20, Setup);
 
-            this.SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, padding1 + parameterCount + padding2, TransData);
+            SMBData = new byte[parameterCount + dataCount + padding1 + padding2];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, padding1 + parameterCount + padding2, TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionSecondaryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TransactionSecondaryRequest.cs
@@ -40,14 +40,14 @@ namespace SMBLibrary.SMB1
 
         public TransactionSecondaryRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            TotalParameterCount = LittleEndianConverter.ToUInt16(this.SMBData, 0);
-            TotalDataCount = LittleEndianConverter.ToUInt16(this.SMBData, 2);
-            ParameterCount = LittleEndianConverter.ToUInt16(this.SMBData, 4);
-            ParameterOffset = LittleEndianConverter.ToUInt16(this.SMBData, 6);
-            ParameterDisplacement = LittleEndianConverter.ToUInt16(this.SMBData, 8);
-            DataCount = LittleEndianConverter.ToUInt16(this.SMBData, 10);
-            DataOffset = LittleEndianConverter.ToUInt16(this.SMBData, 12);
-            DataDisplacement = LittleEndianConverter.ToUInt16(this.SMBData, 14);
+            TotalParameterCount = LittleEndianConverter.ToUInt16(SMBData, 0);
+            TotalDataCount = LittleEndianConverter.ToUInt16(SMBData, 2);
+            ParameterCount = LittleEndianConverter.ToUInt16(SMBData, 4);
+            ParameterOffset = LittleEndianConverter.ToUInt16(SMBData, 6);
+            ParameterDisplacement = LittleEndianConverter.ToUInt16(SMBData, 8);
+            DataCount = LittleEndianConverter.ToUInt16(SMBData, 10);
+            DataOffset = LittleEndianConverter.ToUInt16(SMBData, 12);
+            DataDisplacement = LittleEndianConverter.ToUInt16(SMBData, 14);
 
             TransParameters = ByteReader.ReadBytes(buffer, ParameterOffset, ParameterCount);
             TransData = ByteReader.ReadBytes(buffer, DataOffset, DataCount);
@@ -66,19 +66,19 @@ namespace SMBLibrary.SMB1
             int padding2 = (4 - (DataOffset % 4)) % 4;
             DataOffset += (ushort)padding2;
 
-            this.SMBParameters = new byte[SMBParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, TotalParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, TotalDataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, ParameterCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, ParameterOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, ParameterDisplacement);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, DataCount);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 12, DataOffset);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, DataDisplacement);
+            SMBParameters = new byte[SMBParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, TotalParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, TotalDataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, ParameterCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, ParameterOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, ParameterDisplacement);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, DataCount);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 12, DataOffset);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, DataDisplacement);
 
-            this.SMBData = new byte[ParameterCount + DataCount + padding1 + padding2];
-            ByteWriter.WriteBytes(this.SMBData, padding1, TransParameters);
-            ByteWriter.WriteBytes(this.SMBData, padding1 + ParameterCount + padding2, TransData);
+            SMBData = new byte[ParameterCount + DataCount + padding1 + padding2];
+            ByteWriter.WriteBytes(SMBData, padding1, TransParameters);
+            ByteWriter.WriteBytes(SMBData, padding1 + ParameterCount + padding2, TransData);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXRequest.cs
@@ -36,20 +36,20 @@ namespace SMBLibrary.SMB1
         public TreeConnectAndXRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
             int parametersOffset = 4;
-            Flags = (TreeConnectFlags)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            ushort passwordLength = LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
+            Flags = (TreeConnectFlags)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            ushort passwordLength = LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
 
             int dataOffset = 0;
-            Password = ByteReader.ReadBytes(this.SMBData, ref dataOffset, passwordLength);
+            Password = ByteReader.ReadBytes(SMBData, ref dataOffset, passwordLength);
             if (isUnicode)
             {
                 // wordCount is 1 byte
                 int padding = (1 + passwordLength) % 2;
                 dataOffset += padding;
             }
-            Path = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            Path = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
             // Should be read as OEM string but it doesn't really matter
-            string serviceString = ByteReader.ReadNullTerminatedAnsiString(this.SMBData, ref dataOffset);
+            string serviceString = ByteReader.ReadNullTerminatedAnsiString(SMBData, ref dataOffset);
             Service = ServiceNameHelper.GetServiceName(serviceString);
         }
 
@@ -57,10 +57,10 @@ namespace SMBLibrary.SMB1
         {
             ushort passwordLength = (ushort)Password.Length;
 
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)Flags);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, passwordLength);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)Flags);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, passwordLength);
 
             string serviceString = ServiceNameHelper.GetServiceString(Service);
             int dataLength = Password.Length + serviceString.Length + 1;
@@ -73,17 +73,17 @@ namespace SMBLibrary.SMB1
             {
                 dataLength += Path.Length + 1;
             }
-            this.SMBData = new byte[dataLength];
+            SMBData = new byte[dataLength];
             int dataOffset = 0;
-            ByteWriter.WriteBytes(this.SMBData, ref dataOffset, Password);
+            ByteWriter.WriteBytes(SMBData, ref dataOffset, Password);
             if (isUnicode)
             {
                 // wordCount is 1 byte
                 int padding = (1 + passwordLength) % 2;
                 dataOffset += padding;
             }
-            SMB1Helper.WriteSMBString(this.SMBData, ref dataOffset, isUnicode, Path);
-            ByteWriter.WriteNullTerminatedAnsiString(this.SMBData, ref dataOffset, serviceString);
+            SMB1Helper.WriteSMBString(SMBData, ref dataOffset, isUnicode, Path);
+            ByteWriter.WriteNullTerminatedAnsiString(SMBData, ref dataOffset, serviceString);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXResponse.cs
@@ -33,34 +33,34 @@ namespace SMBLibrary.SMB1
 
         public TreeConnectAndXResponse(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            OptionalSupport = (OptionalSupportFlags)LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
+            OptionalSupport = (OptionalSupportFlags)LittleEndianConverter.ToUInt16(SMBParameters, 4);
 
             int dataOffset = 0;
-            string serviceString = ByteReader.ReadNullTerminatedAnsiString(this.SMBData, ref dataOffset);
-            NativeFileSystem = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            string serviceString = ByteReader.ReadNullTerminatedAnsiString(SMBData, ref dataOffset);
+            NativeFileSystem = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
 
             Service = ServiceNameHelper.GetServiceName(serviceString);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, (ushort)OptionalSupport);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, (ushort)OptionalSupport);
 
             // Should be written as OEM string but it doesn't really matter
             string serviceString = ServiceNameHelper.GetServiceString(Service);
             if (isUnicode)
             {
-                this.SMBData = new byte[serviceString.Length + NativeFileSystem.Length * 2 + 3];
+                SMBData = new byte[serviceString.Length + NativeFileSystem.Length * 2 + 3];
             }
             else
             {
-                this.SMBData = new byte[serviceString.Length + NativeFileSystem.Length + 2];
+                SMBData = new byte[serviceString.Length + NativeFileSystem.Length + 2];
             }
 
             int offset = 0;
-            ByteWriter.WriteNullTerminatedAnsiString(this.SMBData, ref offset, serviceString);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeFileSystem);
+            ByteWriter.WriteNullTerminatedAnsiString(SMBData, ref offset, serviceString);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeFileSystem);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXResponseExtended.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/TreeConnectAndXResponseExtended.cs
@@ -37,39 +37,39 @@ namespace SMBLibrary.SMB1
         public TreeConnectAndXResponseExtended(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
             int parametersOffset = 4;
-            OptionalSupport = (OptionalSupportFlags)LittleEndianReader.ReadUInt16(this.SMBParameters, ref parametersOffset);
-            MaximalShareAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
-            GuestMaximalShareAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(this.SMBParameters, ref parametersOffset);
+            OptionalSupport = (OptionalSupportFlags)LittleEndianReader.ReadUInt16(SMBParameters, ref parametersOffset);
+            MaximalShareAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
+            GuestMaximalShareAccessRights = (AccessMask)LittleEndianReader.ReadUInt32(SMBParameters, ref parametersOffset);
 
             int dataOffset = 0;
-            string serviceString = ByteReader.ReadNullTerminatedAnsiString(this.SMBData, ref dataOffset);
-            NativeFileSystem = SMB1Helper.ReadSMBString(this.SMBData, ref dataOffset, isUnicode);
+            string serviceString = ByteReader.ReadNullTerminatedAnsiString(SMBData, ref dataOffset);
+            NativeFileSystem = SMB1Helper.ReadSMBString(SMBData, ref dataOffset, isUnicode);
 
             Service = ServiceNameHelper.GetServiceName(serviceString);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             int parametersOffset = 4;
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, ref parametersOffset, (ushort)OptionalSupport);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)MaximalShareAccessRights);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, ref parametersOffset, (uint)GuestMaximalShareAccessRights);
+            LittleEndianWriter.WriteUInt16(SMBParameters, ref parametersOffset, (ushort)OptionalSupport);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)MaximalShareAccessRights);
+            LittleEndianWriter.WriteUInt32(SMBParameters, ref parametersOffset, (uint)GuestMaximalShareAccessRights);
 
             // Should be written as OEM string but it doesn't really matter
             string serviceString = ServiceNameHelper.GetServiceString(Service);
             if (isUnicode)
             {
-                this.SMBData = new byte[serviceString.Length + NativeFileSystem.Length * 2 + 3];
+                SMBData = new byte[serviceString.Length + NativeFileSystem.Length * 2 + 3];
             }
             else
             {
-                this.SMBData = new byte[serviceString.Length + NativeFileSystem.Length + 2];
+                SMBData = new byte[serviceString.Length + NativeFileSystem.Length + 2];
             }
 
             int offset = 0;
-            ByteWriter.WriteNullTerminatedAnsiString(this.SMBData, ref offset, serviceString);
-            SMB1Helper.WriteSMBString(this.SMBData, ref offset, isUnicode, NativeFileSystem);
+            ByteWriter.WriteNullTerminatedAnsiString(SMBData, ref offset, serviceString);
+            SMB1Helper.WriteSMBString(SMBData, ref offset, isUnicode, NativeFileSystem);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteAndXRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteAndXRequest.cs
@@ -41,17 +41,17 @@ namespace SMBLibrary.SMB1
 
         public WriteAndXRequest(byte[] buffer, int offset, bool isUnicode) : base(buffer, offset, isUnicode)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            Offset = LittleEndianConverter.ToUInt32(this.SMBParameters, 6);
-            Timeout = LittleEndianConverter.ToUInt32(this.SMBParameters, 10);
-            WriteMode = (WriteMode)LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
-            Remaining = LittleEndianConverter.ToUInt16(this.SMBParameters, 16);
-            ushort dataLengthHigh = LittleEndianConverter.ToUInt16(this.SMBParameters, 18);
-            uint DataLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 20);
-            ushort DataOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 22);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            Offset = LittleEndianConverter.ToUInt32(SMBParameters, 6);
+            Timeout = LittleEndianConverter.ToUInt32(SMBParameters, 10);
+            WriteMode = (WriteMode)LittleEndianConverter.ToUInt16(SMBParameters, 14);
+            Remaining = LittleEndianConverter.ToUInt16(SMBParameters, 16);
+            ushort dataLengthHigh = LittleEndianConverter.ToUInt16(SMBParameters, 18);
+            uint DataLength = LittleEndianConverter.ToUInt16(SMBParameters, 20);
+            ushort DataOffset = LittleEndianConverter.ToUInt16(SMBParameters, 22);
             if (SMBParameters.Length == ParametersFixedLength + 4)
             {
-                uint offsetHigh = LittleEndianConverter.ToUInt32(this.SMBParameters, 24);
+                uint offsetHigh = LittleEndianConverter.ToUInt32(SMBParameters, 24);
                 Offset |= ((ulong)offsetHigh << 32);
             }
 
@@ -78,19 +78,19 @@ namespace SMBLibrary.SMB1
                 DataOffset += 4;
             }
 
-            this.SMBParameters = new byte[parametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, FID);
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 6, (uint)(Offset & 0xFFFFFFFF));
-            LittleEndianWriter.WriteUInt32(this.SMBParameters, 10, Timeout);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 14, (ushort)WriteMode);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 16, Remaining);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 18, dataLengthHigh);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 20, (ushort)(DataLength & 0xFFFF));
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 22, DataOffset);
+            SMBParameters = new byte[parametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, FID);
+            LittleEndianWriter.WriteUInt32(SMBParameters, 6, (uint)(Offset & 0xFFFFFFFF));
+            LittleEndianWriter.WriteUInt32(SMBParameters, 10, Timeout);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 14, (ushort)WriteMode);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 16, Remaining);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 18, dataLengthHigh);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 20, (ushort)(DataLength & 0xFFFF));
+            LittleEndianWriter.WriteUInt16(SMBParameters, 22, DataOffset);
             if (Offset > UInt32.MaxValue)
             {
                 uint offsetHigh = (uint)(Offset >> 32);
-                LittleEndianWriter.WriteUInt32(this.SMBParameters, 24, offsetHigh);
+                LittleEndianWriter.WriteUInt32(SMBParameters, 24, offsetHigh);
             }
 
             int smbDataLength = Data.Length;
@@ -98,13 +98,13 @@ namespace SMBLibrary.SMB1
             {
                 smbDataLength++;
             }
-            this.SMBData = new byte[smbDataLength];
+            SMBData = new byte[smbDataLength];
             int offset = 0;
             if (isUnicode)
             {
                 offset++;
             }
-            ByteWriter.WriteBytes(this.SMBData, ref offset, this.Data);
+            ByteWriter.WriteBytes(SMBData, ref offset, Data);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteAndXResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteAndXResponse.cs
@@ -31,23 +31,23 @@ namespace SMBLibrary.SMB1
 
         public WriteAndXResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            Count = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            Available = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
-            ushort countHigh = LittleEndianConverter.ToUInt16(this.SMBParameters, 8);
-            Reserved = LittleEndianConverter.ToUInt16(this.SMBParameters, 10);
+            Count = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            Available = LittleEndianConverter.ToUInt16(SMBParameters, 6);
+            ushort countHigh = LittleEndianConverter.ToUInt16(SMBParameters, 8);
+            Reserved = LittleEndianConverter.ToUInt16(SMBParameters, 10);
 
             Count |= (uint)(countHigh << 16);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
+            SMBParameters = new byte[ParametersLength];
             ushort counthHigh = (ushort)(Count >> 16);
 
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, (ushort)(Count & 0xFFFF));
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, Available);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 8, counthHigh);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 10, Reserved);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, (ushort)(Count & 0xFFFF));
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, Available);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 8, counthHigh);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 10, Reserved);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawFinalResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawFinalResponse.cs
@@ -24,13 +24,13 @@ namespace SMBLibrary.SMB1
 
         public WriteRawFinalResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            Count = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            Count = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, Count);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, Count);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawInterimResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawInterimResponse.cs
@@ -24,13 +24,13 @@ namespace SMBLibrary.SMB1
 
         public WriteRawInterimResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            Available = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            Available = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, Available);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, Available);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRawRequest.cs
@@ -41,18 +41,18 @@ namespace SMBLibrary.SMB1
 
         public WriteRawRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            CountOfBytes = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
-            Reserved1 = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            Offset = LittleEndianConverter.ToUInt32(this.SMBParameters, 6);
-            Timeout = LittleEndianConverter.ToUInt32(this.SMBParameters, 10);
-            WriteMode = (WriteMode)LittleEndianConverter.ToUInt16(this.SMBParameters, 14);
-            Reserved2 = LittleEndianConverter.ToUInt32(this.SMBParameters, 16);
-            ushort dataLength = LittleEndianConverter.ToUInt16(this.SMBParameters, 20);
-            ushort dataOffset = LittleEndianConverter.ToUInt16(this.SMBParameters, 22);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            CountOfBytes = LittleEndianConverter.ToUInt16(SMBParameters, 2);
+            Reserved1 = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            Offset = LittleEndianConverter.ToUInt32(SMBParameters, 6);
+            Timeout = LittleEndianConverter.ToUInt32(SMBParameters, 10);
+            WriteMode = (WriteMode)LittleEndianConverter.ToUInt16(SMBParameters, 14);
+            Reserved2 = LittleEndianConverter.ToUInt32(SMBParameters, 16);
+            ushort dataLength = LittleEndianConverter.ToUInt16(SMBParameters, 20);
+            ushort dataOffset = LittleEndianConverter.ToUInt16(SMBParameters, 22);
             if (SMBParameters.Length == ParametersFixedLength + 4)
             {
-                OffsetHigh = LittleEndianConverter.ToUInt32(this.SMBParameters, 24);
+                OffsetHigh = LittleEndianConverter.ToUInt32(SMBParameters, 24);
             }
 
             Data = ByteReader.ReadBytes(buffer, dataOffset, dataLength);

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteRequest.cs
@@ -42,18 +42,18 @@ namespace SMBLibrary.SMB1
 
         public WriteRequest(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            FID = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
-            CountOfBytesToWrite = LittleEndianConverter.ToUInt16(this.SMBParameters, 2);
-            WriteOffsetInBytes = LittleEndianConverter.ToUInt16(this.SMBParameters, 4);
-            EstimateOfRemainingBytesToBeWritten = LittleEndianConverter.ToUInt16(this.SMBParameters, 6);
+            FID = LittleEndianConverter.ToUInt16(SMBParameters, 0);
+            CountOfBytesToWrite = LittleEndianConverter.ToUInt16(SMBParameters, 2);
+            WriteOffsetInBytes = LittleEndianConverter.ToUInt16(SMBParameters, 4);
+            EstimateOfRemainingBytesToBeWritten = LittleEndianConverter.ToUInt16(SMBParameters, 6);
 
-            BufferFormat = ByteReader.ReadByte(this.SMBData, 0);
+            BufferFormat = ByteReader.ReadByte(SMBData, 0);
             if (BufferFormat != SupportedBufferFormat)
             {
                 throw new InvalidDataException("Unsupported Buffer Format");
             }
-            ushort dataLength = LittleEndianConverter.ToUInt16(this.SMBData, 1);
-            Data = ByteReader.ReadBytes(this.SMBData, 3, dataLength);
+            ushort dataLength = LittleEndianConverter.ToUInt16(SMBData, 1);
+            Data = ByteReader.ReadBytes(SMBData, 3, dataLength);
         }
 
         public override byte[] GetBytes(bool isUnicode)
@@ -62,16 +62,16 @@ namespace SMBLibrary.SMB1
             {
                 throw new ArgumentException("Invalid Data length");
             }
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, FID);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 2, CountOfBytesToWrite);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 4, WriteOffsetInBytes);
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 6, EstimateOfRemainingBytesToBeWritten);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, FID);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 2, CountOfBytesToWrite);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 4, WriteOffsetInBytes);
+            LittleEndianWriter.WriteUInt16(SMBParameters, 6, EstimateOfRemainingBytesToBeWritten);
 
-            this.SMBData = new byte[3 + Data.Length];
-            ByteWriter.WriteByte(this.SMBData, 0, BufferFormat);
-            LittleEndianWriter.WriteUInt16(this.SMBData, 1, (ushort)Data.Length);
-            ByteWriter.WriteBytes(this.SMBData, 3, Data);
+            SMBData = new byte[3 + Data.Length];
+            ByteWriter.WriteByte(SMBData, 0, BufferFormat);
+            LittleEndianWriter.WriteUInt16(SMBData, 1, (ushort)Data.Length);
+            ByteWriter.WriteBytes(SMBData, 3, Data);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteResponse.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Commands/WriteResponse.cs
@@ -20,13 +20,13 @@ namespace SMBLibrary.SMB1
 
         public WriteResponse(byte[] buffer, int offset) : base(buffer, offset, false)
         {
-            CountOfBytesWritten = LittleEndianConverter.ToUInt16(this.SMBParameters, 0);
+            CountOfBytesWritten = LittleEndianConverter.ToUInt16(SMBParameters, 0);
         }
 
         public override byte[] GetBytes(bool isUnicode)
         {
-            this.SMBParameters = new byte[ParametersLength];
-            LittleEndianWriter.WriteUInt16(this.SMBParameters, 0, CountOfBytesWritten);
+            SMBParameters = new byte[ParametersLength];
+            LittleEndianWriter.WriteUInt16(SMBParameters, 0, CountOfBytesWritten);
 
             return base.GetBytes(isUnicode);
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/SMB1Header.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/SMB1Header.cs
@@ -95,17 +95,17 @@ namespace SMBLibrary.SMB1
         {
             get
             {
-                return (this.Flags2 & HeaderFlags2.ExtendedSecurity) > 0;
+                return (Flags2 & HeaderFlags2.ExtendedSecurity) > 0;
             }
             set
             {
                 if (value)
                 {
-                    this.Flags2 |= HeaderFlags2.ExtendedSecurity;
+                    Flags2 |= HeaderFlags2.ExtendedSecurity;
                 }
                 else
                 {
-                    this.Flags2 &= ~HeaderFlags2.ExtendedSecurity;
+                    Flags2 &= ~HeaderFlags2.ExtendedSecurity;
                 }
             }
         }
@@ -120,11 +120,11 @@ namespace SMBLibrary.SMB1
             {
                 if (value)
                 {
-                    this.Flags2 |= HeaderFlags2.Unicode;
+                    Flags2 |= HeaderFlags2.Unicode;
                 }
                 else
                 {
-                    this.Flags2 &= ~HeaderFlags2.Unicode;
+                    Flags2 &= ~HeaderFlags2.Unicode;
                 }
             }
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/Transaction2Subcommands/Transaction2FindFirst2Request.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/Transaction2Subcommands/Transaction2FindFirst2Request.cs
@@ -90,17 +90,17 @@ namespace SMBLibrary.SMB1
         {
             get
             {
-                return ((this.Flags & FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST) > 0);
+                return ((Flags & FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST) > 0);
             }
             set
             {
                 if (value)
                 {
-                    this.Flags |= FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST;
+                    Flags |= FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST;
                 }
                 else
                 {
-                    this.Flags &= ~FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST;
+                    Flags &= ~FindFlags.SMB_FIND_CLOSE_AFTER_REQUEST;
                 }
             }
         }
@@ -109,17 +109,17 @@ namespace SMBLibrary.SMB1
         {
             get
             {
-                return ((this.Flags & FindFlags.SMB_FIND_CLOSE_AT_EOS) > 0);
+                return ((Flags & FindFlags.SMB_FIND_CLOSE_AT_EOS) > 0);
             }
             set
             {
                 if (value)
                 {
-                    this.Flags |= FindFlags.SMB_FIND_CLOSE_AT_EOS;
+                    Flags |= FindFlags.SMB_FIND_CLOSE_AT_EOS;
                 }
                 else
                 {
-                    this.Flags &= ~FindFlags.SMB_FIND_CLOSE_AT_EOS;
+                    Flags &= ~FindFlags.SMB_FIND_CLOSE_AT_EOS;
                 }
             }
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionCallNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionCallNamedPipeRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, Priority);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionPeekNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionPeekNamedPipeRequest.cs
@@ -29,7 +29,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionQueryNamedPipeInfoRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionQueryNamedPipeInfoRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionRawReadNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionRawReadNamedPipeRequest.cs
@@ -29,7 +29,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionRawWriteNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionRawWriteNamedPipeRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionReadNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionReadNamedPipeRequest.cs
@@ -29,7 +29,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionSetNamedPipeStateRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionSetNamedPipeStateRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionTransactNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionTransactNamedPipeRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionWaitNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionWaitNamedPipeRequest.cs
@@ -29,7 +29,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, Priority);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionWriteNamedPipeRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1/TransactionSubcommands/TransactionWriteNamedPipeRequest.cs
@@ -34,7 +34,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetSetup()
         {
             byte[] setup = new byte[4];
-            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)this.SubcommandName);
+            LittleEndianWriter.WriteUInt16(setup, 0, (ushort)SubcommandName);
             LittleEndianWriter.WriteUInt16(setup, 2, FID);
             return setup;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/ExtendedFileAttributes/ExtendedAttributeNameList.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/ExtendedFileAttributes/ExtendedAttributeNameList.cs
@@ -28,14 +28,14 @@ namespace SMBLibrary.SMB1
             while (position < eof)
             {
                 ExtendedAttributeName attribute = new ExtendedAttributeName(buffer, position);
-                this.Add(attribute);
+                Add(attribute);
                 position += attribute.Length;
             }
         }
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             WriteBytes(buffer, 0);
             return buffer;
         }

--- a/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/ExtendedFileAttributes/FullExtendedAttributeList.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/ExtendedFileAttributes/FullExtendedAttributeList.cs
@@ -39,14 +39,14 @@ namespace SMBLibrary.SMB1
             while (position < eof)
             {
                 FullExtendedAttribute attribute = new FullExtendedAttribute(buffer, position);
-                this.Add(attribute);
+                Add(attribute);
                 position += attribute.Length;
             }
         }
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             WriteBytes(buffer, 0);
             return buffer;
         }
@@ -54,7 +54,7 @@ namespace SMBLibrary.SMB1
         public void WriteBytes(byte[] buffer, ref int offset)
         {
             WriteBytes(buffer, offset);
-            offset += this.Length;
+            offset += Length;
         }
 
         public void WriteBytes(byte[] buffer, int offset)

--- a/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/FindInformation/FindInformationList.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/FindInformation/FindInformationList.cs
@@ -21,7 +21,7 @@ namespace SMBLibrary.SMB1
             while (offset < buffer.Length)
             {
                 FindInformation entry = FindInformation.ReadEntry(buffer, offset, informationLevel, isUnicode);
-                this.Add(entry);
+                Add(entry);
                 if (entry.NextEntryOffset == 0)
                 {
                     break;
@@ -32,7 +32,7 @@ namespace SMBLibrary.SMB1
 
         public byte[] GetBytes(bool isUnicode)
         {
-            for (int index = 0; index < this.Count - 1; index++)
+            for (int index = 0; index < Count - 1; index++)
             {
                 FindInformation entry = this[index];
                 int entryLength = entry.GetLength(isUnicode);
@@ -51,7 +51,7 @@ namespace SMBLibrary.SMB1
         public int GetLength(bool isUnicode)
         {
             int length = 0;
-            for (int index = 0; index < this.Count; index++)
+            for (int index = 0; index < Count; index++)
             {
                 FindInformation entry = this[index];
                 int entryLength = entry.GetLength(isUnicode);

--- a/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/QueryFSInformation/QueryFSAttibuteInfo.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/QueryFSInformation/QueryFSAttibuteInfo.cs
@@ -37,7 +37,7 @@ namespace SMBLibrary.SMB1
         public override byte[] GetBytes(bool isUnicode)
         {
             uint lengthOfFileSystemName = (uint)(FileSystemName.Length * 2);
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             LittleEndianWriter.WriteUInt32(buffer, 0, (uint)FileSystemAttributes);
             LittleEndianWriter.WriteUInt32(buffer, 4, MaxFileNameLengthInBytes);
             LittleEndianWriter.WriteUInt32(buffer, 8, lengthOfFileSystemName);

--- a/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/QueryFSInformation/QueryFSVolumeInfo.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB1FileStore/Structures/QueryFSInformation/QueryFSVolumeInfo.cs
@@ -41,7 +41,7 @@ namespace SMBLibrary.SMB1
         {
             VolumeLabelSize = (uint)(VolumeLabel.Length * 2);
 
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             FileTimeHelper.WriteFileTime(buffer, 0, VolumeCreationTime);
             LittleEndianWriter.WriteUInt32(buffer, 8, SerialNumber);
             LittleEndianWriter.WriteUInt32(buffer, 12, VolumeLabelSize);

--- a/KrbRelay/Smb/SMBLibrary/SMB2/Commands/CloseRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB2/Commands/CloseRequest.cs
@@ -46,7 +46,7 @@ namespace SMBLibrary.SMB2
         {
             get
             {
-                return ((this.Flags & CloseFlags.PostQueryAttributes) > 0);
+                return ((Flags & CloseFlags.PostQueryAttributes) > 0);
             }
         }
 

--- a/KrbRelay/Smb/SMBLibrary/SMB2/Commands/QueryDirectoryRequest.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB2/Commands/QueryDirectoryRequest.cs
@@ -69,7 +69,7 @@ namespace SMBLibrary.SMB2
         {
             get
             {
-                return ((this.Flags & QueryDirectoryFlags.SMB2_RESTART_SCANS) > 0);
+                return ((Flags & QueryDirectoryFlags.SMB2_RESTART_SCANS) > 0);
             }
             set
             {
@@ -88,7 +88,7 @@ namespace SMBLibrary.SMB2
         {
             get
             {
-                return ((this.Flags & QueryDirectoryFlags.SMB2_RETURN_SINGLE_ENTRY) > 0);
+                return ((Flags & QueryDirectoryFlags.SMB2_RETURN_SINGLE_ENTRY) > 0);
             }
             set
             {
@@ -107,7 +107,7 @@ namespace SMBLibrary.SMB2
         {
             get
             {
-                return ((this.Flags & QueryDirectoryFlags.SMB2_REOPEN) > 0);
+                return ((Flags & QueryDirectoryFlags.SMB2_REOPEN) > 0);
             }
             set
             {

--- a/KrbRelay/Smb/SMBLibrary/SMB2/Commands/SMB2Command.cs
+++ b/KrbRelay/Smb/SMBLibrary/SMB2/Commands/SMB2Command.cs
@@ -36,7 +36,7 @@ namespace SMBLibrary.SMB2
 
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[this.Length];
+            byte[] buffer = new byte[Length];
             WriteBytes(buffer, 0);
             return buffer;
         }

--- a/KrbRelay/Smb/SMBLibrary/Server/ConnectionState/SMB1ConnectionState.cs
+++ b/KrbRelay/Smb/SMBLibrary/Server/ConnectionState/SMB1ConnectionState.cs
@@ -116,7 +116,7 @@ namespace SMBLibrary.Server
             {
                 foreach (SMB1Session session in m_sessions.Values)
                 {
-                    result.Add(new SessionInformation(this.ClientEndPoint, this.Dialect, session.UserName, session.MachineName, session.GetOpenFilesInformation(), session.CreationDT));
+                    result.Add(new SessionInformation(ClientEndPoint, Dialect, session.UserName, session.MachineName, session.GetOpenFilesInformation(), session.CreationDT));
                 }
             }
             return result;

--- a/KrbRelay/Smb/SMBLibrary/Server/ConnectionState/SMB2ConnectionState.cs
+++ b/KrbRelay/Smb/SMBLibrary/Server/ConnectionState/SMB2ConnectionState.cs
@@ -96,7 +96,7 @@ namespace SMBLibrary.Server
             {
                 foreach (SMB2Session session in m_sessions.Values)
                 {
-                    result.Add(new SessionInformation(this.ClientEndPoint, this.Dialect, session.UserName, session.MachineName, session.GetOpenFilesInformation(), session.CreationDT));
+                    result.Add(new SessionInformation(ClientEndPoint, Dialect, session.UserName, session.MachineName, session.GetOpenFilesInformation(), session.CreationDT));
                 }
             }
             return result;

--- a/KrbRelay/Smb/SMBLibrary/Server/NameServer.cs
+++ b/KrbRelay/Smb/SMBLibrary/Server/NameServer.cs
@@ -33,7 +33,7 @@ namespace SMBLibrary.Server
                 throw new ArgumentException("NetBIOS name service can only supply IPv4 addresses");
             }
 
-            if (IPAddress.Equals(serverAddress, IPAddress.Any))
+            if (Equals(serverAddress, IPAddress.Any))
             {
                 // When registering a NetBIOS name, we must supply the client with a usable IPAddress.
                 throw new ArgumentException("NetBIOS name service requires an IPAddress that is associated with a specific network interface");
@@ -187,7 +187,7 @@ namespace SMBLibrary.Server
 
                 if (index < 3)
                 {
-                    System.Threading.Thread.Sleep(250);
+                    Thread.Sleep(250);
                 }
             }
         }

--- a/KrbRelay/Smb/SMBLibrary/Server/SMBServer.SMB1.cs
+++ b/KrbRelay/Smb/SMBLibrary/Server/SMBServer.SMB1.cs
@@ -77,7 +77,7 @@ namespace SMBLibrary.Server
                 if (command is NegotiateRequest)
                 {
                     NegotiateRequest request = (NegotiateRequest)command;
-                    if (request.Dialects.Contains(SMBServer.NTLanManagerDialect))
+                    if (request.Dialects.Contains(NTLanManagerDialect))
                     {
                         state = new SMB1ConnectionState(state);
                         state.Dialect = SMBDialect.NTLM012;

--- a/KrbRelay/Smb/SMBLibrary/Server/Shares/SMBShareCollection.cs
+++ b/KrbRelay/Smb/SMBLibrary/Server/Shares/SMBShareCollection.cs
@@ -14,12 +14,12 @@ namespace SMBLibrary.Server
     {
         public bool Contains(string shareName, StringComparison comparisonType)
         {
-            return (this.IndexOf(shareName, comparisonType) != -1);
+            return (IndexOf(shareName, comparisonType) != -1);
         }
 
         public int IndexOf(string shareName, StringComparison comparisonType)
         {
-            for (int index = 0; index < this.Count; index++)
+            for (int index = 0; index < Count; index++)
             {
                 if (this[index].Name.Equals(shareName, comparisonType))
                 {

--- a/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo0Container.cs
+++ b/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo0Container.cs
@@ -36,7 +36,7 @@ namespace SMBLibrary.Services
         public void Write(NDRWriter writer)
         {
             writer.BeginStructure();
-            writer.WriteUInt32((uint)this.Count);
+            writer.WriteUInt32((uint)Count);
             writer.WriteEmbeddedStructureFullPointer(Entries);
             writer.EndStructure();
         }

--- a/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo1Container.cs
+++ b/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo1Container.cs
@@ -36,7 +36,7 @@ namespace SMBLibrary.Services
         public void Write(NDRWriter writer)
         {
             writer.BeginStructure();
-            writer.WriteUInt32((uint)this.Count);
+            writer.WriteUInt32((uint)Count);
             writer.WriteEmbeddedStructureFullPointer(Entries);
             writer.EndStructure();
         }

--- a/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo2Container.cs
+++ b/KrbRelay/Smb/SMBLibrary/Services/ServerService/Structures/ShareInfo/ShareInfo2Container.cs
@@ -36,7 +36,7 @@ namespace SMBLibrary.Services
         public void Write(NDRWriter writer)
         {
             writer.BeginStructure();
-            writer.WriteUInt32((uint)this.Count);
+            writer.WriteUInt32((uint)Count);
             writer.WriteEmbeddedStructureFullPointer(Entries);
             writer.EndStructure();
         }

--- a/KrbRelay/Smb/Utilities/ByteUtils/ByteReader.cs
+++ b/KrbRelay/Smb/Utilities/ByteUtils/ByteReader.cs
@@ -69,12 +69,12 @@ namespace Utilities
         public static string ReadNullTerminatedAnsiString(byte[] buffer, int offset)
         {
             StringBuilder builder = new StringBuilder();
-            char c = (char)ByteReader.ReadByte(buffer, offset);
+            char c = (char)ReadByte(buffer, offset);
             while (c != '\0')
             {
                 builder.Append(c);
                 offset++;
-                c = (char)ByteReader.ReadByte(buffer, offset);
+                c = (char)ReadByte(buffer, offset);
             }
             return builder.ToString();
         }

--- a/KrbRelay/Smb/Utilities/ByteUtils/ByteReader.cs
+++ b/KrbRelay/Smb/Utilities/ByteUtils/ByteReader.cs
@@ -44,7 +44,7 @@ namespace Utilities
         {
             // ASCIIEncoding.ASCII.GetString will convert some values to '?' (byte value of 63)
             // Any codepage will do, but the only one that Mono supports is 28591.
-            return ASCIIEncoding.GetEncoding(28591).GetString(buffer, offset, count);
+            return Encoding.GetEncoding(28591).GetString(buffer, offset, count);
         }
 
         public static string ReadAnsiString(byte[] buffer, ref int offset, int count)
@@ -126,7 +126,7 @@ namespace Utilities
         public static string ReadAnsiString(Stream stream, int length)
         {
             byte[] buffer = ReadBytes(stream, length);
-            return ASCIIEncoding.GetEncoding(28591).GetString(buffer);
+            return Encoding.GetEncoding(28591).GetString(buffer);
         }
 
         public static string ReadNullTerminatedAnsiString(Stream stream)

--- a/KrbRelay/Smb/Utilities/ByteUtils/ByteWriter.cs
+++ b/KrbRelay/Smb/Utilities/ByteUtils/ByteWriter.cs
@@ -58,7 +58,7 @@ namespace Utilities
 
         public static void WriteAnsiString(byte[] buffer, int offset, string value, int maximumLength)
         {
-            byte[] bytes = ASCIIEncoding.GetEncoding(28591).GetBytes(value);
+            byte[] bytes = Encoding.GetEncoding(28591).GetBytes(value);
             Array.Copy(bytes, 0, buffer, offset, Math.Min(value.Length, maximumLength));
         }
 
@@ -80,7 +80,7 @@ namespace Utilities
 
         public static void WriteUTF16String(byte[] buffer, int offset, string value, int maximumNumberOfCharacters)
         {
-            byte[] bytes = UnicodeEncoding.Unicode.GetBytes(value);
+            byte[] bytes = Encoding.Unicode.GetBytes(value);
             int maximumNumberOfBytes = Math.Min(value.Length, maximumNumberOfCharacters) * 2;
             Array.Copy(bytes, 0, buffer, offset, maximumNumberOfBytes);
         }
@@ -132,7 +132,7 @@ namespace Utilities
 
         public static void WriteAnsiString(Stream stream, string value, int fieldLength)
         {
-            byte[] bytes = ASCIIEncoding.GetEncoding(28591).GetBytes(value);
+            byte[] bytes = Encoding.GetEncoding(28591).GetBytes(value);
             stream.Write(bytes, 0, Math.Min(bytes.Length, fieldLength));
             if (bytes.Length < fieldLength)
             {
@@ -143,19 +143,19 @@ namespace Utilities
 
         public static void WriteUTF8String(Stream stream, string value)
         {
-            byte[] bytes = UnicodeEncoding.UTF8.GetBytes(value);
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
             stream.Write(bytes, 0, bytes.Length);
         }
 
         public static void WriteUTF16String(Stream stream, string value)
         {
-            byte[] bytes = UnicodeEncoding.Unicode.GetBytes(value);
+            byte[] bytes = Encoding.Unicode.GetBytes(value);
             stream.Write(bytes, 0, bytes.Length);
         }
 
         public static void WriteUTF16BEString(Stream stream, string value)
         {
-            byte[] bytes = UnicodeEncoding.BigEndianUnicode.GetBytes(value);
+            byte[] bytes = Encoding.BigEndianUnicode.GetBytes(value);
             stream.Write(bytes, 0, bytes.Length);
         }
     }

--- a/KrbRelay/Smb/Utilities/Cryptography/CRC32.cs
+++ b/KrbRelay/Smb/Utilities/Cryptography/CRC32.cs
@@ -44,7 +44,7 @@ namespace Utilities
         protected override byte[] HashFinal()
         {
             byte[] hashBuffer = UInt32ToBigEndianBytes(~hash);
-            this.HashValue = hashBuffer;
+            HashValue = hashBuffer;
             return hashBuffer;
         }
 

--- a/KrbRelay/Smb/Utilities/Cryptography/CRC32.cs
+++ b/KrbRelay/Smb/Utilities/Cryptography/CRC32.cs
@@ -104,7 +104,7 @@ namespace Utilities
 
         private byte[] UInt32ToBigEndianBytes(UInt32 x)
         {
-            return new byte[] {
+            return new[] {
                 (byte)((x >> 24) & 0xff),
                 (byte)((x >> 16) & 0xff),
                 (byte)((x >> 8) & 0xff),

--- a/KrbRelay/Smb/Utilities/Generics/KeyValuePairList.Sort.cs
+++ b/KrbRelay/Smb/Utilities/Generics/KeyValuePairList.Sort.cs
@@ -14,7 +14,7 @@ namespace Utilities
     {
         public new void Sort()
         {
-            this.Sort(Comparer<TKey>.Default);
+            Sort(Comparer<TKey>.Default);
         }
 
         public void Sort(ListSortDirection sortDirection)
@@ -36,7 +36,7 @@ namespace Utilities
 
         public void Sort(IComparer<TKey> comparer)
         {
-            this.Sort(delegate (KeyValuePair<TKey, TValue> a, KeyValuePair<TKey, TValue> b)
+            Sort(delegate (KeyValuePair<TKey, TValue> a, KeyValuePair<TKey, TValue> b)
             {
                 return comparer.Compare(a.Key, b.Key);
             });

--- a/KrbRelay/Smb/Utilities/Generics/KeyValuePairList.cs
+++ b/KrbRelay/Smb/Utilities/Generics/KeyValuePairList.cs
@@ -21,12 +21,12 @@ namespace Utilities
 
         public bool ContainsKey(TKey key)
         {
-            return (this.IndexOfKey(key) != -1);
+            return (IndexOfKey(key) != -1);
         }
 
         public int IndexOfKey(TKey key)
         {
-            for (int index = 0; index < this.Count; index++)
+            for (int index = 0; index < Count; index++)
             {
                 if (this[index].Key.Equals(key))
                 {
@@ -39,7 +39,7 @@ namespace Utilities
 
         public TValue ValueOf(TKey key)
         {
-            for (int index = 0; index < this.Count; index++)
+            for (int index = 0; index < Count; index++)
             {
                 if (this[index].Key.Equals(key))
                 {
@@ -52,7 +52,7 @@ namespace Utilities
 
         public void Add(TKey key, TValue value)
         {
-            this.Add(new KeyValuePair<TKey, TValue>(key, value));
+            Add(new KeyValuePair<TKey, TValue>(key, value));
         }
 
         public List<TKey> Keys

--- a/KrbRelay/Spoofing/HttpServer.cs
+++ b/KrbRelay/Spoofing/HttpServer.cs
@@ -21,17 +21,17 @@ namespace KrbRelay.Spoofing
 
         public HttpServer(string ip, int port, string service)
         {
-            this.listener = new TcpListener(IPAddress.Parse(ip), port);
+            listener = new TcpListener(IPAddress.Parse(ip), port);
             this.service = service;
         }
 
         public void Start()
         {
-            this.listener.Start();
+            listener.Start();
             var result = "Access denied";
             while (true)
             {
-                var client = this.listener.AcceptTcpClient();
+                var client = listener.AcceptTcpClient();
                 NetworkStream stream = client.GetStream();
                 var buffer = new byte[10240];
                 //var length = stream.Read(buffer, 0, buffer.Length);

--- a/KrbRelay/Spoofing/HttpServer.cs
+++ b/KrbRelay/Spoofing/HttpServer.cs
@@ -2,9 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Net;
-using System.Threading.Tasks;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;

--- a/KrbRelay/Spoofing/HttpServer.cs
+++ b/KrbRelay/Spoofing/HttpServer.cs
@@ -94,8 +94,6 @@ namespace KrbRelay.Spoofing
 
     internal class HttpRelayServer
     {
-
-
         public static void start(string Service, string argSpooferIP)
         {
             Console.WriteLine("[*] Listening for connections on http://{0}:80", argSpooferIP);
@@ -207,12 +205,10 @@ namespace KrbRelay.Spoofing
                 //Program.stopSpoofing = true;
 
                 //Kerberos auth may not require set-cookies
-                IEnumerable<string> cookies = null;
                 foreach (var h in result.Headers)
                 {
                     if (h.Key == "Set-Cookie")
                     {
-                        cookies = h.Value;
                         Console.WriteLine("[*] Authentication Cookie;\n" + string.Join(";", h.Value));
                     }
                 }

--- a/KrbRelay/Spoofing/LLMNR.cs
+++ b/KrbRelay/Spoofing/LLMNR.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Net;
 using System.Net.Sockets;

--- a/KrbRelay/Spoofing/LLMNR.cs
+++ b/KrbRelay/Spoofing/LLMNR.cs
@@ -151,7 +151,5 @@ namespace KrbRelay.Spoofing
 
             return llmnrMemoryStream.ToArray();
         }
-
     }
-
 }

--- a/KrbRelay/Spoofing/LLMNR.cs
+++ b/KrbRelay/Spoofing/LLMNR.cs
@@ -41,25 +41,25 @@ namespace KrbRelay.Spoofing
                 {
                     byte[] udpPayload = llmnrClient.Receive(ref llmnrEndpoint);
                     byte[] llmnrType = new byte[2];
-                    System.Buffer.BlockCopy(udpPayload, (udpPayload.Length - 4), llmnrType, 0, 2);
+                    Buffer.BlockCopy(udpPayload, (udpPayload.Length - 4), llmnrType, 0, 2);
                     int llmnrSourcePort = llmnrEndpoint.Port;
 
                     if (BitConverter.ToString(llmnrType) != "00-1C")
                     {
                         string llmnrResponseMessage = "";
                         byte[] llmnrTransactionID = new byte[2];
-                        System.Buffer.BlockCopy(udpPayload, 0, llmnrTransactionID, 0, 2);
+                        Buffer.BlockCopy(udpPayload, 0, llmnrTransactionID, 0, 2);
                         byte[] llmnrRequest = new byte[udpPayload.Length - 18];
                         byte[] llmnrRequestLength = new byte[1];
-                        System.Buffer.BlockCopy(udpPayload, 12, llmnrRequestLength, 0, 1);
-                        System.Buffer.BlockCopy(udpPayload, 13, llmnrRequest, 0, llmnrRequest.Length);
+                        Buffer.BlockCopy(udpPayload, 12, llmnrRequestLength, 0, 1);
+                        Buffer.BlockCopy(udpPayload, 13, llmnrRequest, 0, llmnrRequest.Length);
                         string llmnrRequestHost = Util.ParseNameQuery(12, udpPayload);
                         IPAddress sourceIPAddress = llmnrEndpoint.Address;
                         llmnrResponseMessage = Util.CheckRequest(llmnrRequestHost, sourceIPAddress.ToString(), IP.ToString(), "LLMNR", null, null);
 
                         if (String.Equals(llmnrResponseMessage, "response sent"))
                         {
-                            byte[] llmnrResponse = LLMNR.GetLLMNRResponse("listener", ipVersion, llmnrTTL, sourceIPAddress, destinationIPAddress, spooferIPData, spooferIPv6Data, Util.IntToByteArray2(llmnrSourcePort), udpPayload, spn);
+                            byte[] llmnrResponse = GetLLMNRResponse("listener", ipVersion, llmnrTTL, sourceIPAddress, destinationIPAddress, spooferIPData, spooferIPv6Data, Util.IntToByteArray2(llmnrSourcePort), udpPayload, spn);
                             IPEndPoint llmnrDestinationEndPoint = new IPEndPoint(sourceIPAddress, llmnrSourcePort);
                             UDP.UDPListenerClient(sourceIPAddress, llmnrSourcePort, llmnrClient, llmnrResponse);
                             llmnrClient = UDP.UDPListener("LLMNR", IP, 5355, ipVersion);
@@ -83,13 +83,13 @@ namespace KrbRelay.Spoofing
             byte[] ttlLLMNR = BitConverter.GetBytes(Int32.Parse(llmnrTTL));
             Array.Reverse(ttlLLMNR);
             byte[] llmnrType = new byte[2];
-            System.Buffer.BlockCopy(udpPayload, (udpPayload.Length - 4), llmnrType, 0, 2);
+            Buffer.BlockCopy(udpPayload, (udpPayload.Length - 4), llmnrType, 0, 2);
             byte[] llmnrTransactionID = new byte[2];
-            System.Buffer.BlockCopy(udpPayload, 0, llmnrTransactionID, 0, 2);
+            Buffer.BlockCopy(udpPayload, 0, llmnrTransactionID, 0, 2);
             byte[] llmnrRequest = new byte[udpPayload.Length - 18];
             byte[] llmnrRequestLength = new byte[1];
-            System.Buffer.BlockCopy(udpPayload, 12, llmnrRequestLength, 0, 1);
-            System.Buffer.BlockCopy(udpPayload, 13, llmnrRequest, 0, llmnrRequest.Length);
+            Buffer.BlockCopy(udpPayload, 12, llmnrRequestLength, 0, 1);
+            Buffer.BlockCopy(udpPayload, 13, llmnrRequest, 0, llmnrRequest.Length);
             MemoryStream llmnrMemoryStream = new MemoryStream();
 
             //Console.WriteLine(String.Format("[{0}] ", ByteArrayToString(llmnrRequest)));

--- a/KrbRelay/Spoofing/UDP.cs
+++ b/KrbRelay/Spoofing/UDP.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 
 namespace KrbRelay.Spoofing
 {

--- a/KrbRelay/Spoofing/UDP.cs
+++ b/KrbRelay/Spoofing/UDP.cs
@@ -39,7 +39,6 @@ namespace KrbRelay.Spoofing
                 {
                     udpClient.JoinMulticastGroup(IPAddress.Parse("ff02::1:2"));
                 }
-
             }
             catch
             {
@@ -81,6 +80,5 @@ namespace KrbRelay.Spoofing
             udpSendSocket.SendTo(udpResponse, destinationEndpoint);
             udpSendSocket.Close();
         }
-
     }
 }

--- a/KrbRelay/Spoofing/Util.cs
+++ b/KrbRelay/Spoofing/Util.cs
@@ -288,7 +288,7 @@ namespace KrbRelay.Spoofing
         {
             string hostname = "";
             byte[] queryLength = new byte[1];
-            System.Buffer.BlockCopy(nameQuery, index, queryLength, 0, 1);
+            Buffer.BlockCopy(nameQuery, index, queryLength, 0, 1);
             int hostnameLength = queryLength[0];
             int i = 0;
 
@@ -296,7 +296,7 @@ namespace KrbRelay.Spoofing
             {
                 int hostnameSegmentLength = hostnameLength;
                 byte[] hostnameSegment = new byte[hostnameSegmentLength];
-                System.Buffer.BlockCopy(nameQuery, (index + 1), hostnameSegment, 0, hostnameSegmentLength);
+                Buffer.BlockCopy(nameQuery, (index + 1), hostnameSegment, 0, hostnameSegmentLength);
                 hostname += Encoding.UTF8.GetString(hostnameSegment);
                 index += hostnameLength + 1;
                 hostnameLength = nameQuery[index];

--- a/KrbRelay/Spoofing/Util.cs
+++ b/KrbRelay/Spoofing/Util.cs
@@ -13,7 +13,6 @@ namespace KrbRelay.Spoofing
     {
         public static string GetLocalIPAddress(string ipVersion)
         {
-
             List<string> ipAddressList = new List<string>();
             AddressFamily addressFamily;
 
@@ -28,10 +27,8 @@ namespace KrbRelay.Spoofing
 
             foreach (NetworkInterface networkInterface in NetworkInterface.GetAllNetworkInterfaces())
             {
-
                 if (networkInterface.NetworkInterfaceType == NetworkInterfaceType.Ethernet && networkInterface.OperationalStatus == OperationalStatus.Up)
                 {
-
                     foreach (UnicastIPAddressInformation ip in networkInterface.GetIPProperties().UnicastAddresses)
                     {
 
@@ -39,11 +36,8 @@ namespace KrbRelay.Spoofing
                         {
                             ipAddressList.Add(ip.Address.ToString());
                         }
-
                     }
-
                 }
-
             }
 
             return ipAddressList.FirstOrDefault();
@@ -319,7 +313,5 @@ namespace KrbRelay.Spoofing
 
             return hostname;
         }
-
     }
-
 }

--- a/KrbRelay/Spoofing/Util.cs
+++ b/KrbRelay/Spoofing/Util.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Collections.Generic;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.IO;
 
 namespace KrbRelay.Spoofing
 {


### PR DESCRIPTION
Just some general code cleanup:
- Fixed 2 spelling mistakes printed in the console
- Removed redundant qualifiers, namespace usings and type specifiers
- Changed subclasses such as `UnicodeEncoding.Unicode.GetString()` to be `Encoding.Unicode.GetString()`. It is identical code, but more readable.